### PR TITLE
Add sync.sh script to automatically sync to different repository

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -1,0 +1,2 @@
+/scripts
+

--- a/scripts/publish_test.sh
+++ b/scripts/publish_test.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+echo "dart format..."
+
+dart format lib/
+dart format test/
+
+echo "flutter pub dry run..."
+flutter pub publish --dry-run
+#flutter pub publish
+

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -2,7 +2,7 @@
 
 # git remote add
 echo -e "\n[git remote add ...]"
-git remote add private-sync git@github.com:iLib-js/flutter_ilib_webos.git
+git remote add sync-private git@github.com:iLib-js/flutter_ilib_webos.git
 
 # git sync with public flutter_ilib main(release) branch
 git reset --hard
@@ -11,7 +11,7 @@ git fetch origin
 git rebase remotes/origin/main
 
 echo -e "\n[sync branch ...]"
-git push private-sync HEAD:public/sync
+git push sync-private HEAD:public/sync
 
 # sync tag
 echo -e "\n[tags ...]"
@@ -25,7 +25,7 @@ done
  
 # upload tag to flutter_ilib_webos
 echo -e "\n[sync tag ...]"
-git push --tags private-sync
+git push --tags sync-private
 
 echo -e "\n[git remote remove ...]"
-git remote remove private-sync
+git remote remove sync-private

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# git remote add
+echo -e "\n[git remote add ...]"
+git remote add private-sync git@github.com:iLib-js/flutter_ilib_webos.git
+
+# git sync with public flutter_ilib main(release) branch
+git reset --hard
+git checkout main
+git fetch origin 
+git rebase remotes/origin/main
+
+echo -e "\n[sync branch ...]"
+git push private-sync HEAD:public/sync
+
+# sync tag
+echo -e "\n[tags ...]"
+git for-each-ref --format="%(refname:short) %(objectname)" refs/tags |
+while read ref
+do
+        values=($ref)
+        echo "tags ${values[0]}"
+        #git tag -a ${values[0]} -m 'import tag from sf tag ${values[0]}' ${values[1]}
+done
+ 
+# upload tag to flutter_ilib_webos
+echo -e "\n[sync tag ...]"
+git push --tags private-sync
+
+echo -e "\n[git remote remove ...]"
+git remote remove private-sync

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -7,7 +7,6 @@ git remote add sync-private git@github.com:iLib-js/flutter_ilib_webos.git
 # git sync with public flutter_ilib main(release) branch
 git reset --hard
 git checkout main
-git fetch origin 
 git rebase remotes/origin/main
 
 echo -e "\n[sync branch ...]"
@@ -20,12 +19,8 @@ while read ref
 do
         values=($ref)
         echo "tags ${values[0]}"
-        #git tag -a ${values[0]} -m 'import tag from sf tag ${values[0]}' ${values[1]}
 done
  
 # upload tag to flutter_ilib_webos
 echo -e "\n[sync tag ...]"
 git push --tags sync-private
-
-echo -e "\n[git remote remove ...]"
-git remote remove sync-private

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
-# git remote add
-echo -e "\n[git remote add ...]"
-git remote add sync-private git@github.com:iLib-js/flutter_ilib_webos.git
-
 # git sync with public flutter_ilib main(release) branch
 git reset --hard
 git checkout main
 git rebase remotes/origin/main
+
+# git remote add
+echo -e "\n[git remote add ...]"
+git remote add sync-private git@github.com:iLib-js/flutter_ilib_webos.git
 
 echo -e "\n[sync branch ...]"
 git push sync-private HEAD:public/sync


### PR DESCRIPTION
Add a `sync.sh` script to automatically sync the main branch to the private [flutter_ilib_webos](https://github.com/iLib-js/flutter_ilib_webos) repository. 

The `flutter_ilib_webos` repository serves the same role as the `release_webos` branch here, but it is private. (The webos-related branch will be removed here.)
The main branch and tags are synced to the public/sync branch in flutter_ilib_webos. 

Here is the result after executing the `sync.sh` script.
https://github.com/iLib-js/flutter_ilib_webos/tree/public/sync