### PR TITLE
Add `isILibReady` getter to access to ILibJS initialization status.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.0
+* Added `isReady` getter to `ILibJS` class to expose internal `_iLibPrepared` state.
+* Added `isReady` getter to `FlutterILib` class for external access to ILibJS initialization status.
+
 ## 1.1.0
 * Updated the iLib files to version 14.21.0 since the new version of iLib has been released.
   * iLib version 14.21.0 incorporates CLDR 46

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.2.0
-* Added `isReady` getter to `ILibJS` class to expose internal `_iLibPrepared` state.
-* Added `isReady` getter to `FlutterILib` class for external access to ILibJS initialization status.
+* Added `isILibReady` getter to `ILibJS` class to expose internal `_iLibPrepared` state.
+* Added `isILibReady` getter to `FlutterILib` class for external access to ILibJS initialization status.
 
 ## 1.1.0
 * Updated the iLib files to version 14.21.0 since the new version of iLib has been released.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -52,7 +52,7 @@ class _MyAppState extends State<MyApp> {
       if (!mounted) {
         return;
       }
-      if (!_flutterIlibPlugin.isReady) {
+      if (!_flutterIlibPlugin.isILibReady) {
         _flutterIlibPlugin.addListener(() => updateState());
       } else {
         updateState();

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -52,7 +52,11 @@ class _MyAppState extends State<MyApp> {
       if (!mounted) {
         return;
       }
-      _flutterIlibPlugin.addListener(() => updateState());
+      if (!_flutterIlibPlugin.isReady) {
+        _flutterIlibPlugin.addListener(() => updateState());
+      } else {
+        updateState();
+      }
     });
   }
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -89,7 +89,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.1.0"
+    version: "1.2.0"
   flutter_js:
     dependency: transitive
     description:

--- a/lib/flutter_ilib.dart
+++ b/lib/flutter_ilib.dart
@@ -20,7 +20,7 @@ class FlutterILib extends ChangeNotifier {
   static FlutterILib get instance => _instance;
 
   /// Return whether iLib is ready
-  bool get isReady => ILibJS.instance.isReady;
+  bool get isILibReady => ILibJS.instance.isILibReady;
 
   /// Return the current version of iLib.
   String? get getVersion => evaluateILib('''ilib.getVersion()''');

--- a/lib/flutter_ilib.dart
+++ b/lib/flutter_ilib.dart
@@ -19,6 +19,9 @@ class FlutterILib extends ChangeNotifier {
   static final FlutterILib _instance = FlutterILib._internal();
   static FlutterILib get instance => _instance;
 
+  /// Return whether iLib is ready
+  bool get isReady => ILibJS.instance.isReady;
+
   /// Return the current version of iLib.
   String? get getVersion => evaluateILib('''ilib.getVersion()''');
 

--- a/lib/ilib_init.dart
+++ b/lib/ilib_init.dart
@@ -10,6 +10,7 @@ class ILibJS extends ChangeNotifier {
 
   static final ILibJS _instance = ILibJS._internal();
   static ILibJS get instance => _instance;
+  bool get isReady => _iLibPrepared;
 
   final JavascriptRuntime _jsRuntime = getJavascriptRuntime();
   bool _iLibPrepared = false;

--- a/lib/ilib_init.dart
+++ b/lib/ilib_init.dart
@@ -10,7 +10,7 @@ class ILibJS extends ChangeNotifier {
 
   static final ILibJS _instance = ILibJS._internal();
   static ILibJS get instance => _instance;
-  bool get isReady => _iLibPrepared;
+  bool get isILibReady => _iLibPrepared;
 
   final JavascriptRuntime _jsRuntime = getJavascriptRuntime();
   bool _iLibPrepared = false;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -53,10 +53,10 @@ packages:
     dependency: transitive
     description:
       name: ffi
-      sha256: "7bf0adc28a23d395f19f3f1eb21dd7cfd1dd9f8e1c50051c069122e6853bc878"
+      sha256: "16ed7b077ef01ad6170a3d0c57caa4a112a38d7a2ed5602e0aca9ca6f3d98da6"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.3"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -66,10 +66,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_js
-      sha256: d19cde4bad2f7c301ff5f69d7b3452ff91f2ca89d153569dd03e544579d8610d
+      sha256: a04966b102967891ee4947d6e52b450676f16204876ba936e394008ca26db04b
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.1"
+    version: "0.8.5"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -87,10 +87,10 @@ packages:
     dependency: transitive
     description:
       name: http
-      sha256: "759d1a329847dd0f39226c688d3e06a6b8679668e350e2891a6474f8b4bb8525"
+      sha256: "2c11f3f94c687ee9bad77c171151672986360b2b001d109814ee7140b2cf261b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.4.0"
   http_parser:
     dependency: transitive
     description:
@@ -256,6 +256,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "14.2.1"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
 sdks:
-  dart: ">=3.3.0 <4.0.0"
+  dart: ">=3.4.0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_ilib
 description: "A wrapper plugin to conveniently use 'iLib' in Flutter app for internationalization. This plugin uses the 'flutter_js' to make the JavaScript file work properly in the Flutter app."
-version: 1.1.0
+version: 1.2.0
 homepage: https://github.com/iLib-js/flutter_ilib
 repository: https://github.com/iLib-js/flutter_ilib
 

--- a/test/basic/flutter_ilib_test.dart
+++ b/test/basic/flutter_ilib_test.dart
@@ -37,6 +37,6 @@ void main() {
       const String str = '';
       expect(flutterIlibPlugin.evaluateILib(str), null);
     });
-    test('isReady', () => expect(flutterIlibPlugin.isReady, true));
+    test('isILibReady', () => expect(flutterIlibPlugin.isILibReady, true));
   });
 }

--- a/test/basic/flutter_ilib_test.dart
+++ b/test/basic/flutter_ilib_test.dart
@@ -37,5 +37,6 @@ void main() {
       const String str = '';
       expect(flutterIlibPlugin.evaluateILib(str), null);
     });
+    test('isReady', () => expect(flutterIlibPlugin.isReady, true));
   });
 }


### PR DESCRIPTION
### Checklist

The following lists affects Pub Points on pub.dev when the package is published.
* [x] Passed the all tests.
* [x] Verified that the example app works.
* [x] Executed the `dart format` command.
* [x] Added the API description is added if necessary.

Added a `isReady` getter to allow applications using this to check its initialization status.