### PR TITLE
Fix incorrect timezone handling when DateTime is UTC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.2.1
+* Fixed incorrect timezone handling when [DateTime](https://api.flutter.dev/flutter/dart-core/DateTime-class.html) where UTC-based times were being misinterpreted as local time during formatting and parsing.
+
 ## 1.2.0
 * Added `isILibReady` getter to `ILibJS` class to expose internal `_iLibPrepared` state.
 * Added `isILibReady` getter to `FlutterILib` class for external access to ILibJS initialization status.

--- a/lib/ilib_datefmt.dart
+++ b/lib/ilib_datefmt.dart
@@ -205,7 +205,9 @@ class ILibDateOptions {
 
     final Map<String, String> paramInfo = <String, String>{
       'locale': '$locale',
-      'timezone': '$timezone',
+      // If dateTime is not null and is in UTC, set timezone to 'Etc/UTC'.
+      // Otherwise, use the provided timezone value.
+      'timezone': (dateTime?.isUtc ?? false) ? 'Etc/UTC' : '$timezone',
       'type': '$type',
       'calendar': '$calendar'
     };

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -131,6 +131,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
+  logging:
+    dependency: "direct main"
+    description:
+      name: logging
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_ilib
 description: "A wrapper plugin to conveniently use 'iLib' in Flutter app for internationalization. This plugin uses the 'flutter_js' to make the JavaScript file work properly in the Flutter app."
-version: 1.2.0
+version: 1.2.1
 homepage: https://github.com/iLib-js/flutter_ilib
 repository: https://github.com/iLib-js/flutter_ilib
 

--- a/test/basic/flutter_ilib_datefmt_test.dart
+++ b/test/basic/flutter_ilib_datefmt_test.dart
@@ -73,13 +73,21 @@ void main() {
           ILibDateOptions(dateTime: DateTime.parse('2024-06-27 10:42'));
       expect(fmt.format(dateOptions), '2024년 6월 27일 오전 10:42');
     });
-    test('ILibDateFmt_DateTimeObj_utc', () {
+    test('ILibDateFmt_DateTimeObj_utc_koKR', () {
       final ILibDateFmtOptions fmtOptions = ILibDateFmtOptions(
           locale: 'ko-KR', length: 'full', type: 'datetime', useNative: false);
       final ILibDateFmt fmt = ILibDateFmt(fmtOptions);
       final ILibDateOptions dateOptions =
           ILibDateOptions(dateTime: DateTime.parse('2024-06-27 10:42Z'));
       expect(fmt.format(dateOptions), '2024년 6월 27일 오후 7:42');
+    });
+    test('ILibDateFmt_DateTimeObj_utc_enUS', () {
+      final ILibDateFmtOptions fmtOptions = ILibDateFmtOptions(
+          locale: 'en-US', length: 'full', type: 'datetime', useNative: false);
+      final ILibDateFmt fmt = ILibDateFmt(fmtOptions);
+      final ILibDateOptions dateOptions =
+          ILibDateOptions(dateTime: DateTime.utc(2024, 6, 27, 10, 42));
+      expect(fmt.format(dateOptions), 'June 27, 2024 at 6:42 AM');
     });
   });
   group('getClock()', () {

--- a/test/basic/flutter_ilib_datefmt_test.dart
+++ b/test/basic/flutter_ilib_datefmt_test.dart
@@ -73,6 +73,14 @@ void main() {
           ILibDateOptions(dateTime: DateTime.parse('2024-06-27 10:42'));
       expect(fmt.format(dateOptions), '2024년 6월 27일 오전 10:42');
     });
+    test('ILibDateFmt_DateTimeObj_utc', () {
+      final ILibDateFmtOptions fmtOptions = ILibDateFmtOptions(
+          locale: 'ko-KR', length: 'full', type: 'datetime', useNative: false);
+      final ILibDateFmt fmt = ILibDateFmt(fmtOptions);
+      final ILibDateOptions dateOptions =
+          ILibDateOptions(dateTime: DateTime.parse('2024-06-27 10:42Z'));
+      expect(fmt.format(dateOptions), '2024년 6월 27일 오후 7:42');
+    });
   });
   group('getClock()', () {
     test('getClock_ko_KR', () {


### PR DESCRIPTION
### Checklist

The following lists affects Pub Points on pub.dev when the package is published.
* [x] Passed the all tests.
* [x] Verified that the example app works.
* [x] Executed the `dart format` command.
* [x] Added the API description is added if necessary.

### Description
* Fixed incorrect timezone handling when [DateTime](https://api.flutter.dev/flutter/dart-core/DateTime-class.html) where UTC-based times were being misinterpreted as local time during formatting and parsing.