### PR TITLE
Implement ILibCaseMapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 * Add new methods to `ILibLocaleInfo`:  
 `getLanguageName()`, `getRegionName()`, `getClock()`, `getLocale()`, `getUnits()`, `getCalendar()`, `getTimeZone()`, `getPrimaryGroupingDigits()`, `getSecondaryGroupingDigits()`, `getPercentageSymbol()`, `getExponential()`, `getNativeExponential()`, `getNativePercentageSymbol()`, `getNegativeNumberFormat()`, `getDigitsStyle()`, `getDigits()`, `getNativeDigits()`, `getRoundingMode()`, `getScript()`, `getDefaultScript()`, `getAllScripts()`, `getMeridiemsStyle()`, `getPaperSize()`, `getDelimiterQuotationStart()`, `getDelimiterQuotationEnd()`
 * Implement `ILibLocale`
-* Implement `ILibCaseMapper'
+* Implement `ILibCaseMapper`
 
 ## 1.6.0
 * Implement the `ILibNumFmt` class to enable NumberFormatting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Add new methods to `ILibLocaleInfo`:  
 `getLanguageName()`, `getRegionName()`, `getClock()`, `getLocale()`, `getUnits()`, `getCalendar()`, `getTimeZone()`, `getPrimaryGroupingDigits()`, `getSecondaryGroupingDigits()`, `getPercentageSymbol()`, `getExponential()`, `getNativeExponential()`, `getNativePercentageSymbol()`, `getNegativeNumberFormat()`, `getDigitsStyle()`, `getDigits()`, `getNativeDigits()`, `getRoundingMode()`, `getScript()`, `getDefaultScript()`, `getAllScripts()`, `getMeridiemsStyle()`, `getPaperSize()`, `getDelimiterQuotationStart()`, `getDelimiterQuotationEnd()`
 * Implement `ILibLocale`
+* Implement `ILibCaseMapper'
 
 ## 1.6.0
 * Implement the `ILibNumFmt` class to enable NumberFormatting

--- a/Docs.md
+++ b/Docs.md
@@ -198,3 +198,47 @@ ILibNumFmt(ILibNumFmtOptions options)
 |_String_ getRoundingMode()| Returns the rounding mode set up in the constructor. |
 |_String_ getStyle()| Returns the style used to construct this number formatter object. |
 |_bool_ getUseNative()| Returns true if this formatter uses native digits to format the number. |
+
+# ScriptInfo
+## ILibScriptInfo
+### Properties
+|name|description|
+|------|---|
+|_String?_ script|The ISO 15924 4-letter identifier for the script.|
+
+### Constructors
+```dart
+ILibScriptInfo(String script)
+```
+
+### Methods
+|name|description|
+|------|---|
+|_String?_ getCode()|Return the 4-letter ISO 15924 identifier associated with this script.|
+|_int?_ getCodeNumber()|Get the ISO 15924 code number associated with this script.|
+|_String?_ getName()|Get the name of this script in English.|
+|_String?_ getLongCode()|Get the long identifier associated with this script.|
+|_String_ getScriptDirection()|Return the usual direction that text in this script is written in. Possible values: "rtl", "ltr", "ttb".|
+|_bool_ getNeedsIME()|Return true if this script typically requires an input method engine to enter its characters.|
+|_bool_ getCasing()|Return true if this script uses lower- and upper-case characters.|
+
+# CaseMapper
+## ILibCaseMapper
+### Constructors
+```dart
+ILibCaseMapper({String? locale, String? direction})
+```
+
+### Properties
+|name|description|
+|------|---|
+|_bool_ up|Indicates whether the mapper is set to convert to upper case (true) or lower case (false).|
+|_ILibLocale_ locale|The locale used for locale-sensitive case mapping.|
+|_Map<String, String>_ mapData|The mapping data used for case conversion.|
+
+### Methods
+|name|description|
+|------|---|
+|_ILibLocale_ getLocale()|Return the locale that this mapper was constructed with.|
+|_String?_ map(String? string)|Map a string to upper or lower case in a locale-sensitive manner.|
+

--- a/Docs.md
+++ b/Docs.md
@@ -139,7 +139,6 @@ ILibLocale([Object? language, String? region, String? variant, String? script])
 |_bool_ equals(ILibLocale other)|Check if another locale is exactly equal to this one.|
 |_bool_ isPseudo()|Check if the locale is a pseudo-locale. Pseudo-locales are used for testing localization.|
 |_bool_ isValid()|Check if the locale uses valid ISO codes for its components. Validates language, script, and region codes.|
-|_List<String>_ getAvailableLocales()|Return a list of all available locales (not implemented).|
 
 
 ## ILibLocaleInfo

--- a/Docs.md
+++ b/Docs.md
@@ -111,6 +111,37 @@ ILibDurationFmt(ILibDurationFmtOptions options)
 
 
 # LocaleInfo
+## ILibLocale
+### Properties
+|name|description|
+|------|---|
+|_String_ language|The ISO 639 2-letter code for the language, or a full locale spec in BCP-47 format, or another `ILibLocale` instance to copy from.|
+|_String?_ script|The ISO 15924 code of the script for this locale, if any.|
+|_String?_ region|The ISO 3166 2-letter code for the region.|
+|_String?_ variant|The name of the variant of this locale, if any.|
+
+### Constructors
+```dart
+ILibLocale([Object? language, String? region, String? variant, String? script])
+```
+
+### Methods
+|name|description|
+|------|---|
+|_String_ getLanguage()|Return the ISO 639 language code of the locale.|
+|_String?_ getLanguageAlpha3()|Return the ISO 639-3 language code of the locale.|
+|_String?_ getScript()|Return the ISO 15924 script code of the locale.|
+|_String?_ getRegion()|Return the ISO 3166 region code of the locale.|
+|_String?_ getRegionAlpha3()|Return the ISO 3166-3 region code of the locale.|
+|_String?_ getVariant()|Return the variant code of the locale.|
+|_String_ getSpec()|Return the full locale specifier as a string.|
+|_String_ getLangSpec()|Return the language and script specifier of the locale.|
+|_bool_ equals(ILibLocale other)|Check if another locale is exactly equal to this one.|
+|_bool_ isPseudo()|Check if the locale is a pseudo-locale. Pseudo-locales are used for testing localization.|
+|_bool_ isValid()|Check if the locale uses valid ISO codes for its components. Validates language, script, and region codes.|
+|_List<String>_ getAvailableLocales()|Return a list of all available locales (not implemented).|
+
+
 ## ILibLocaleInfo
 ### Properties
 |name|description|
@@ -221,24 +252,4 @@ ILibScriptInfo(String script)
 |_String_ getScriptDirection()|Return the usual direction that text in this script is written in. Possible values: "rtl", "ltr", "ttb".|
 |_bool_ getNeedsIME()|Return true if this script typically requires an input method engine to enter its characters.|
 |_bool_ getCasing()|Return true if this script uses lower- and upper-case characters.|
-
-# CaseMapper
-## ILibCaseMapper
-### Constructors
-```dart
-ILibCaseMapper({String? locale, String? direction})
-```
-
-### Properties
-|name|description|
-|------|---|
-|_bool_ up|Indicates whether the mapper is set to convert to upper case (true) or lower case (false).|
-|_ILibLocale_ locale|The locale used for locale-sensitive case mapping.|
-|_Map<String, String>_ mapData|The mapping data used for case conversion.|
-
-### Methods
-|name|description|
-|------|---|
-|_ILibLocale_ getLocale()|Return the locale that this mapper was constructed with.|
-|_String?_ map(String? string)|Map a string to upper or lower case in a locale-sensitive manner.|
 

--- a/Docs.md
+++ b/Docs.md
@@ -115,10 +115,10 @@ ILibDurationFmt(ILibDurationFmtOptions options)
 ### Properties
 |name|description|
 |------|---|
-|_String_ language|The ISO 639 2-letter code for the language, or a full locale spec in BCP-47 format, or another `ILibLocale` instance to copy from.|
+|_Object?_ language|The ISO 639 2-letter code for the language, or a full locale spec in BCP-47 format, or another `ILibLocale` instance to copy from.|
 |_String?_ script|The ISO 15924 code of the script for this locale, if any.|
-|_String?_ region|The ISO 3166 2-letter code for the region.|
 |_String?_ variant|The name of the variant of this locale, if any.|
+|_String?_ region|The ISO 3166 2-letter code for the region.|
 
 ### Constructors
 ```dart
@@ -252,3 +252,21 @@ ILibScriptInfo(String script)
 |_bool_ getNeedsIME()|Return true if this script typically requires an input method engine to enter its characters.|
 |_bool_ getCasing()|Return true if this script uses lower- and upper-case characters.|
 
+# CaseMapper
+## ILibCaseMapper
+### Properties
+|name|description|
+|------|---|
+|_String?_ locale|The locale to use for case mapping. Defaults to the system locale if not provided.|
+|_String?_ direction|Indicates whether the mapper is set to convert to uppercase (`true`) or lowercase (`false`).|
+
+### Constructors
+```dart
+ILibCaseMapper({String? locale, String? direction})
+```
+
+### Methods
+|name|description|
+|------|---|
+|_ILibLocale_ getLocale()|Returns the locale used by this mapper.|
+|_String?_ map(String? string)|Maps a string to uppercase or lowercase in a locale-sensitive manner.|

--- a/README.md
+++ b/README.md
@@ -196,20 +196,27 @@ To give a more efficient way, we provide some classes that can be easily used in
 Currently, we have the following classes:
 - `ILibCaseMapper`
 - `ILibDateFmt`
-- `ILibLocaleInfo`
+- `ILibDateOptions`
 - `ILibDurationFmt`
+- `ILibLocale`
+- `ILibLocaleInfo`
 - `ILibNumFmt`
 - `ILibScriptInfo`
 
 We have a plan to provide more classes and methods.  
 
-### ILibDate
-- Class: [ILibDateOptions](./Docs.md/#ilibdateoptions)
-
 ### ILibDateFmt
-- Class: [ILibDateFmtOptions](./Docs.md/#ilibdatefmtoptions)  
+- Class: [ILibDateFmtOptions](./Docs.md/#ilibdatefmtoptions)
 - Class: [ILibDateFmt](./Docs.md#ilibdatefmt)
    - Methods: `format()`, `getClock()`, `getTemplate()`, `getMeridiemsRange()`
+
+### ILibDurationFmt
+- Class: [ILibDurationFmtOptions](./Docs.md/#ilibdurationfmtoptions)
+- Class: [ILibDurationFmt](./Docs.md/#ilibdurationfmt)
+   - Methods:  `format()`, `getLocale()`, `getStyle()`, `getLength()`
+
+### ILibDateOptions
+- Class: [ILibDateOptions](./Docs.md/#ilibdateoptions)
 
 ### ILibLocale
 - Class: [ILibLocale](./Docs.md/#iliblocale)
@@ -217,11 +224,6 @@ We have a plan to provide more classes and methods.
 ### ILibLocaleInfo
 - Class: [ILibLocaleInfo](./Docs.md/#iliblocaleinfo)
   - Methods: `getLanguageName()`, `getRegionName()`, `getClock()`, `getLocale()`, `getUnits()`, `getCalendar()`, `getFirstDayOfWeek()`, `getWeekEndStart()`, `getWeekEndEnd()`, `getTimeZone()`, `getDecimalSeparator()`, `getNativeDecimalSeparator()`, `getGroupingSeparator()`, `getNativeGroupingSeparator()`, `getPrimaryGroupingDigits()`, `getSecondaryGroupingDigits()`, `getPercentageFormat()`, `getNegativePercentageFormat()`, `getPercentageSymbol()`, `getExponential()`, `getNativeExponential()`, `getNativePercentageSymbol()`, `getNegativeNumberFormat()`, `getCurrencyFormats()`, `getCurrency()`, `getDigitsStyle()`, `getDigits()`, `getNativeDigits()`, `getRoundingMode()`, `getScript()`, `getDefaultScript()`, `getAllScripts()`, `getMeridiemsStyle()`, `getPaperSize()`, `getDelimiterQuotationStart()`, `getDelimiterQuotationEnd()`
-
-### ILibDurationFmt
-- Class: [ILibDurationFmtOptions](./Docs.md/#ilibdurationfmtoptions)
-- Class: [ILibDurationFmt](./Docs.md/#ilibdurationfmt)
-   - Methods:  `format()`, `getLocale()`, `getStyle()`, `getLength()`
 
 ### ILibNumFmt
 - Clasee: [ILibNumFmtOptions](./Docs.md/#ilibnumfmtoptions)

--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ _flutterIlibPlugin.evaluateILib(jscode1);
 ```
 To give a more efficient way, we provide some classes that can be easily used in a Flutter app.   
 Currently, we have the following classes:
+- `ILibCaseMapper`
 - `ILibDateFmt`
 - `ILibLocaleInfo`
 - `ILibDurationFmt`

--- a/README.md
+++ b/README.md
@@ -169,6 +169,17 @@ scInfo.getScriptDirection();
 // 'ltr'
 ```
 
+## CaseMapper
+``` dart
+final ILibCaseMapper mapper = ILibCaseMapper(locale: 'tr-TR');
+mapper.map('ıi');
+// 'Iİ'
+final ILibCaseMapper mapper = ILibCaseMapper(
+    locale: 'tr-TR', direction: 'tolower');
+mapper.map('Iİ');
+// 'ıi'
+```
+
 ## CLASS
 
 ### FlutterILib
@@ -219,6 +230,10 @@ We have a plan to provide more classes and methods.
 ### ILibScriptInfo
 - Class: [ILibScriptInfo](./Docs.md/#ilibscriptinfo)
    - Methods: `getCode()`, `getCodeNumber()`, `getName()`, `getLongCode()`, `getScriptDirection()`, `getNeedsIME()`, `getCasing()`
+
+### ILibCaseMapper
+- Class: [ILibCaseMapper](./Docs.md/#ilibcasemapper)
+  - Methods: `getLocale()`, `map()`
 
 ## Supported Locales
 The results of the following locales are checked by unit tests.  

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -161,6 +161,8 @@ class _MyAppState extends State<MyApp> {
               _customTextBox('iLib Version', _iLibVersion, main: false),
               _customTextBox('CLDR Version', _iLibCLDRVersion, main: false),
               _customTextBox('Current Time', _currentTime),
+              _customTextBox('Upper Case', getUpperLowerCase('el-GR', 'groß'), main: false),
+              _customTextBox('Lower Case', getUpperLowerCase('tr-TR', 'Iİ', direction: 'tolower'), main: false),
             ],
           ),
         ),
@@ -228,5 +230,13 @@ class _MyAppState extends State<MyApp> {
     final ILibDateFmtOptions fmtOptions = ILibDateFmtOptions(locale: curlo);
     final int clock = ILibDateFmt(fmtOptions).getClock();
     return '$clock';
+  }
+
+  String getUpperLowerCase(String curlo, String str, {String direction = 'toupper'}) {
+    final ILibCaseMapper caseMapper =
+        ILibCaseMapper(locale: curlo, direction: direction);
+    String? result = caseMapper.map(str)?? '';
+    String? result2 = '$str\t($curlo)\t($direction)\t-->\t$result';
+    return result2;
   }
 }

--- a/lib/flutter_ilib.dart
+++ b/lib/flutter_ilib.dart
@@ -6,6 +6,7 @@ import 'ilib_init.dart';
 import 'internal/logger/log_adapter.dart';
 import 'internal/logger/logger_selector.dart';
 
+export 'ilib_casemapper.dart';
 export 'ilib_date.dart';
 export 'ilib_datefmt.dart';
 export 'ilib_durationfmt.dart';

--- a/lib/ilib_casemapper.dart
+++ b/lib/ilib_casemapper.dart
@@ -28,20 +28,30 @@ class ILibCaseMapper {
       };
     }
 
-    switch (this.locale.getLanguage()) {
-      case 'az':
-      case 'tr':
-      case 'crh':
-      case 'kk':
-      case 'krc':
-      case 'tt':
-        _setUpMap('iı', 'İI');
-        break;
+    const Set<String> specialLanguages = {'az', 'tr', 'crh', 'kk', 'krc', 'tt'};
+    if (specialLanguages.contains(this.locale.getLanguage())) {
+      _setUpMap('iı', 'İI');
     }
   }
   bool up;
   ILibLocale locale;
   Map<String, String> mapData = <String, String>{};
+
+  String _handleGreekSigma(String string, int i) {
+    if (i < string.length) {
+      final String nextChar = string[i];
+      final int code = nextChar.codeUnitAt(0);
+      // If the next char is not a Greek letter, this is the end of the word,
+      // so use the final form of sigma. Otherwise, use the mid-word form.
+      final bool isNotGreek =
+          (code < 0x0388 && code != 0x0386) || code > 0x03CE;
+      return (isNotGreek ? 'ς' : 'σ') + nextChar.toLowerCase();
+    } else {
+      // No next char means this is the end of the word,
+      // so use the final form of sigma.
+      return 'ς';
+    }
+  }
 
   String? _charMapper(String? string) {
     if (string == null || string.isEmpty) {
@@ -57,29 +67,12 @@ class ILibCaseMapper {
       i++;
 
       if (!up && c == 'Σ') {
+        buffer.write(_handleGreekSigma(string, i));
         if (i < len) {
-          final String nextChar = string[i];
           i++;
-
-          final int code = nextChar.codeUnitAt(0);
-
-          // if the next char is not a greek letter, this is the end of the word so use the
-          // final form of sigma. Otherwise, use the mid-word form.
-          final bool isNotGreek =
-              (code < 0x0388 && code != 0x0386) || code > 0x03CE;
-          buffer.write(isNotGreek ? 'ς' : 'σ');
-
-          buffer.write(nextChar.toLowerCase());
-        } else {
-          // no next char means this is the end of the word, so use the final form of sigma
-          buffer.write('ς');
         }
       } else {
-        if (mapData.containsKey(c)) {
-          buffer.write(mapData[c]);
-        } else {
-          buffer.write(up ? c.toUpperCase() : c.toLowerCase());
-        }
+        buffer.write(mapData[c] ?? (up ? c.toUpperCase() : c.toLowerCase()));
       }
     }
 

--- a/lib/ilib_casemapper.dart
+++ b/lib/ilib_casemapper.dart
@@ -2,6 +2,9 @@ import 'flutter_ilib.dart';
 
 /// A class that maps a string to upper or lower case in a locale-sensitive manner.
 class ILibCaseMapper {
+  /// [locale] locale to use when loading the mapper
+  /// [direction] "toupper" for upper-casing, or "tolower" for lower-casing.
+  /// Default if not specified is "toupper".
   ILibCaseMapper({String? locale, String? direction})
       : up = direction == null || direction == 'toupper',
         locale = locale != null ? ILibLocale(locale) : ILibLocale() {

--- a/lib/ilib_casemapper.dart
+++ b/lib/ilib_casemapper.dart
@@ -1,0 +1,107 @@
+import 'flutter_ilib.dart';
+
+/// A class that maps a string to upper or lower case in a locale-sensitive manner.
+class ILibCaseMapper {
+  ILibCaseMapper({String? locale, String? direction})
+      : up = direction == null || direction == 'toupper',
+        locale = locale != null ? ILibLocale(locale) : ILibLocale() {
+    if (up) {
+      mapData = <String, String>{
+        'ß': 'SS', // German
+        'ΐ': 'Ι', // Greek
+        'ά': 'Α',
+        'έ': 'Ε',
+        'ή': 'Η',
+        'ί': 'Ι',
+        'ΰ': 'Υ',
+        'ϊ': 'Ι',
+        'ϋ': 'Υ',
+        'ό': 'Ο',
+        'ύ': 'Υ',
+        'ώ': 'Ω',
+        'Ӏ': 'Ӏ', // Russian and slavic languages
+        'ӏ': 'Ӏ'
+      };
+    } else {
+      mapData = <String, String>{
+        'Ӏ': 'Ӏ' // Russian and slavic languages
+      };
+    }
+
+    switch (this.locale.getLanguage()) {
+      case 'az':
+      case 'tr':
+      case 'crh':
+      case 'kk':
+      case 'krc':
+      case 'tt':
+        _setUpMap('iı', 'İI');
+        break;
+    }
+  }
+  bool up;
+  ILibLocale locale;
+  Map<String, String> mapData = <String, String>{};
+
+  String? _charMapper(String? string) {
+    if (string == null || string.isEmpty) {
+      return string;
+    }
+
+    final StringBuffer buffer = StringBuffer();
+    int i = 0;
+    final int len = string.length;
+
+    while (i < len) {
+      String c = string[i];
+      i++;
+
+      if (!up && c == 'Σ') {
+        if (i < len) {
+          String nextChar = string[i];
+          i++;
+
+          int code = nextChar.codeUnitAt(0);
+
+          // if the next char is not a greek letter, this is the end of the word so use the
+          // final form of sigma. Otherwise, use the mid-word form.
+          bool isNotGreek = (code < 0x0388 && code != 0x0386) || code > 0x03CE;
+          buffer.write(isNotGreek ? 'ς' : 'σ');
+
+          buffer.write(nextChar.toLowerCase());
+        } else {
+          // no next char means this is the end of the word, so use the final form of sigma
+          buffer.write('ς');
+        }
+      } else {
+        if (mapData.containsKey(c)) {
+          buffer.write(mapData[c]);
+        } else {
+          buffer.write(up ? c.toUpperCase() : c.toLowerCase());
+        }
+      }
+    }
+
+    return buffer.toString();
+  }
+
+  void _setUpMap(String lower, String upper) {
+    for (int i = 0; i < lower.length; i++) {
+      if (up) {
+        mapData[lower[i]] = upper[i];
+      } else {
+        mapData[upper[i]] = lower[i];
+      }
+    }
+  }
+
+  /// Return the locale that this mapper was constructed with.
+  ILibLocale getLocale() {
+    return locale;
+  }
+
+  /// Map a string to lower case in a locale-sensitive manner.
+  String? map(String? string) {
+    return _charMapper(string);
+  }
+}

--- a/lib/ilib_casemapper.dart
+++ b/lib/ilib_casemapper.dart
@@ -53,19 +53,20 @@ class ILibCaseMapper {
     final int len = string.length;
 
     while (i < len) {
-      String c = string[i];
+      final String c = string[i];
       i++;
 
       if (!up && c == 'Σ') {
         if (i < len) {
-          String nextChar = string[i];
+          final String nextChar = string[i];
           i++;
 
-          int code = nextChar.codeUnitAt(0);
+          final int code = nextChar.codeUnitAt(0);
 
           // if the next char is not a greek letter, this is the end of the word so use the
           // final form of sigma. Otherwise, use the mid-word form.
-          bool isNotGreek = (code < 0x0388 && code != 0x0386) || code > 0x03CE;
+          final bool isNotGreek =
+              (code < 0x0388 && code != 0x0386) || code > 0x03CE;
           buffer.write(isNotGreek ? 'ς' : 'σ');
 
           buffer.write(nextChar.toLowerCase());

--- a/lib/ilib_casemapper.dart
+++ b/lib/ilib_casemapper.dart
@@ -28,7 +28,14 @@ class ILibCaseMapper {
       };
     }
 
-    const Set<String> specialLanguages = {'az', 'tr', 'crh', 'kk', 'krc', 'tt'};
+    const Set<String> specialLanguages = <String>{
+      'az',
+      'tr',
+      'crh',
+      'kk',
+      'krc',
+      'tt'
+    };
     if (specialLanguages.contains(this.locale.getLanguage())) {
       _setUpMap('iı', 'İI');
     }

--- a/lib/ilib_date.dart
+++ b/lib/ilib_date.dart
@@ -47,7 +47,7 @@ class ILibDateOptions {
   String toJsonString() {
     int? y = year;
     int? m = month;
-    int? w = week;
+    final int? w = week;
     int? d = day;
     int? h = hour;
     int? min = minute;

--- a/lib/ilib_date.dart
+++ b/lib/ilib_date.dart
@@ -47,7 +47,6 @@ class ILibDateOptions {
   String toJsonString() {
     int? y = year;
     int? m = month;
-    final int? w = week;
     int? d = day;
     int? h = hour;
     int? min = minute;
@@ -55,6 +54,7 @@ class ILibDateOptions {
     int? milsec = millisecond;
     String result = '';
     String completeOption = '';
+    final int? w = week;
 
     if (dateTime != null) {
       y = dateTime!.year;

--- a/lib/ilib_datefmt.dart
+++ b/lib/ilib_datefmt.dart
@@ -101,7 +101,7 @@ class ILibDateFmt {
   List<MeridiemsInfo> getMeridiemsRange() {
     String result = '';
     final String formatOptions = toJsonString();
-    final List<MeridiemsInfo> meridems = [];
+    final List<MeridiemsInfo> meridems = <MeridiemsInfo>[];
     final String jscode1 =
         'JSON.stringify(new DateFmt($formatOptions).getMeridiemsRange())';
     result = ILibJS.instance.evaluate(jscode1).stringResult;

--- a/lib/ilib_locale.dart
+++ b/lib/ilib_locale.dart
@@ -926,7 +926,7 @@ class ILibLocale {
   }
 
   /// A list of all known pseudo-locales.
-  static List<String> pseudoLocales = [
+  static List<String> pseudoLocales = <String>[
     'zxx-XX',
     'zxx-Cyrl-XX',
     'zxx-Hans-XX',

--- a/lib/internal/ilib_utils.dart
+++ b/lib/internal/ilib_utils.dart
@@ -32,7 +32,7 @@ bool isValidLocale(String lo) {
 }
 
 List<String> getSupportedLanguages() {
-  final List<String> locales = [
+  final List<String> locales = <String>[
     'af',
     'am',
     'ar',

--- a/test/casemapper/lower_test.dart
+++ b/test/casemapper/lower_test.dart
@@ -1,0 +1,204 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_ilib/flutter_ilib.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  debugPrint('Testing [lower_test.dart] file.');
+
+  group('ILibCaseMapper-lower', () {
+    test('testToLowerFromLower_default', () {
+      final ILibCaseMapper mapper = ILibCaseMapper(direction: 'tolower');
+      expect(mapper.map('this is a string'), 'this is a string');
+    });
+    test('testToLowerFromUpper_default', () {
+      final ILibCaseMapper mapper = ILibCaseMapper(direction: 'tolower');
+      expect(mapper.map('THIS IS A STRING'), 'this is a string');
+    });
+    test('testToLowerFromMixed_default', () {
+      final ILibCaseMapper mapper = ILibCaseMapper(direction: 'tolower');
+      expect(mapper.map('This is a String'), 'this is a string');
+    });
+    test('testToLowerFromPunctuationUnchanged_default', () {
+      final ILibCaseMapper mapper = ILibCaseMapper(direction: 'tolower');
+      expect(mapper.map(r'!@#$%^&*()'), r'!@#$%^&*()');
+    });
+    test('testToLowerFromNonLatinUnchanged_default', () {
+      final ILibCaseMapper mapper = ILibCaseMapper(direction: 'tolower');
+      expect(mapper.map('演蟻人 道格拉斯最老英雄'), '演蟻人 道格拉斯最老英雄');
+    });
+    test('testToLowerFromExtendedLatin_default', () {
+      final ILibCaseMapper mapper = ILibCaseMapper(direction: 'tolower');
+      expect(mapper.map('ÃÉÌÔÜ'), 'ãéìôü');
+    });
+    test('testToLowerCyrillic_default', () {
+      final ILibCaseMapper mapper = ILibCaseMapper(direction: 'tolower');
+      expect(mapper.map('ПРАЗЛ'), 'празл');
+    });
+    test('testToLowerGreek_default', () {
+      final ILibCaseMapper mapper = ILibCaseMapper(direction: 'tolower');
+      expect(mapper.map('ΑΒΓΔΕΖΗΘ'), 'αβγδεζηθ');
+    });
+    test('testToLowerGreekSigma_default', () {
+      final ILibCaseMapper mapper = ILibCaseMapper(direction: 'tolower');
+      expect(mapper.map('ΙΑΣΑΣ ΙΑΣΑΣ'), 'ιασας ιασας');
+    });
+    test('testToLowerCoptic_default', () {
+      final ILibCaseMapper mapper = ILibCaseMapper(direction: 'tolower');
+      expect(mapper.map('ⲀⲂⲄⲆⲈⲊⲌⲎⲐⲒⲔⲖ'), 'ⲁⲃⲅⲇⲉⲋⲍⲏⲑⲓⲕⲗ');
+    });
+    test('testToLowerArmenian_default', () {
+      final ILibCaseMapper mapper = ILibCaseMapper(direction: 'tolower');
+      expect(mapper.map('ԱԲԳԴԵԶԷԸԹ'), 'աբգդեզէըթ');
+    });
+    test('testToLowerGeorgian_default', () {
+      final ILibCaseMapper mapper = ILibCaseMapper(direction: 'tolower');
+      expect(mapper.map('ႠႡႢႣႤႥႦႧႨႩ'), 'ⴀⴁⴂⴃⴄⴅⴆⴇⴈⴉ');
+    });
+    /* Azeri tests */
+    test('testToLower_az_AZ', () {
+      final ILibCaseMapper mapper =
+          ILibCaseMapper(direction: 'tolower', locale: 'az-AZ');
+      expect(mapper.map('Iİ'), 'ıi');
+    });
+    /* Turkish tests */
+    test('testToLower_tr_TR', () {
+      final ILibCaseMapper mapper =
+          ILibCaseMapper(direction: 'tolower', locale: 'tr-TR');
+      expect(mapper.map('Iİ'), 'ıi');
+    });
+    /* Crimean Tatar tests */
+    test('testToLower_crh_Latn_UK', () {
+      final ILibCaseMapper mapper =
+          ILibCaseMapper(direction: 'tolower', locale: 'crh-Latn-UK');
+      expect(mapper.map('Iİ'), 'ıi');
+    });
+    /* Kazakh tests */
+    test('testToLower_kk_Latn_KK', () {
+      final ILibCaseMapper mapper =
+          ILibCaseMapper(direction: 'tolower', locale: 'kk-Latn-KK');
+      expect(mapper.map('Iİ'), 'ıi');
+    });
+    /* Tatar tests */
+    test('testToLower_tt_Latn_RU', () {
+      final ILibCaseMapper mapper =
+          ILibCaseMapper(direction: 'tolower', locale: 'tt-Latn-RU');
+      expect(mapper.map('Iİ'), 'ıi');
+    });
+    /* Karachay-Balkar tests */
+    test('testToLower_krc_Latn_RU', () {
+      final ILibCaseMapper mapper =
+          ILibCaseMapper(direction: 'tolower', locale: 'krc-Latn-RU');
+      expect(mapper.map('Iİ'), 'ıi');
+    });
+    /* German tests */
+    test('testToLowerDoubleS_de_DE', () {
+      final ILibCaseMapper mapper =
+          ILibCaseMapper(direction: 'tolower', locale: 'de-DE');
+      expect(mapper.map('GROSS'), 'gross');
+    });
+    test('testToLowerWithSZ_de_DE', () {
+      final ILibCaseMapper mapper =
+          ILibCaseMapper(direction: 'tolower', locale: 'de-DE');
+      expect(mapper.map('GROß'), 'groß');
+    });
+    /* Russian tests */
+    test('testToLowerLowerPalochka_ru_RU', () {
+      final ILibCaseMapper mapper =
+          ILibCaseMapper(direction: 'tolower', locale: 'ru-RU');
+      expect(mapper.map('ӏ'), 'ӏ');
+    });
+    test('testToLowerUpperPalochka_ru_RU', () {
+      final ILibCaseMapper mapper =
+          ILibCaseMapper(direction: 'tolower', locale: 'ru-RU');
+      expect(mapper.map('Ӏ'), 'Ӏ');
+    });
+    /* Greek tests */
+    test('testToLower_el_GR', () {
+      final ILibCaseMapper mapper =
+          ILibCaseMapper(direction: 'tolower', locale: 'el-GR');
+      expect(mapper.map('ΙΑΣΑΣ ΙΑΣΑΣ'), 'ιασας ιασας');
+    });
+    /* French tests */
+    test('testToLowerNoAccents_fr_FR', () {
+      final ILibCaseMapper mapper =
+          ILibCaseMapper(direction: 'tolower', locale: 'fr-FR');
+      expect(mapper.map('TETE-A-TETE'), 'tete-a-tete');
+    });
+    test('testToLowerWithAccents_fr_FR', () {
+      final ILibCaseMapper mapper =
+          ILibCaseMapper(direction: 'tolower', locale: 'fr-FR');
+      expect(mapper.map('TÊTE-À-TÊTE'), 'tête-à-tête');
+    });
+    test('testToLowerMixedWithAccents_fr_FR', () {
+      final ILibCaseMapper mapper =
+          ILibCaseMapper(direction: 'tolower', locale: 'fr-FR');
+      expect(mapper.map('Tête-à-Tête'), 'tête-à-tête');
+    });
+    /* French Canadian tests */
+    test('testToLower_fr_CA', () {
+      final ILibCaseMapper mapper =
+          ILibCaseMapper(direction: 'tolower', locale: 'fr-CA');
+      expect(mapper.map('TÊTE-À-TÊTE'), 'tête-à-tête');
+    });
+    //make sure it is not broken in Lithuanian
+    test('testToLower_lt', () {
+      final ILibCaseMapper mapper =
+          ILibCaseMapper(direction: 'tolower', locale: 'lt-LT');
+      expect(mapper.map('AĄBCČDEĘĖFGHIĮYJKLMNOPRSŠTUŲŪVZŽ'),
+          'aąbcčdeęėfghiįyjklmnoprsštuųūvzž');
+    });
+    /*Afrikaan Test cases*/
+    test('testToLower_af_ZA1', () {
+      final ILibCaseMapper mapper =
+          ILibCaseMapper(direction: 'tolower', locale: 'af-ZA');
+      expect(mapper.map('AÁÄBCDEÊËÉÈFG'), 'aáäbcdeêëéèfg');
+    });
+    test('testToLower_af_ZA2', () {
+      final ILibCaseMapper mapper =
+          ILibCaseMapper(direction: 'tolower', locale: 'af-ZA');
+      expect(mapper.map('HIÎÏÍJKLMNOÔÖÓPQRSTUÛÜÚVWXYZ'),
+          'hiîïíjklmnoôöópqrstuûüúvwxyz');
+    });
+    test('testToLowerMixed_af_ZA3', () {
+      final ILibCaseMapper mapper =
+          ILibCaseMapper(direction: 'tolower', locale: 'af-ZA');
+      expect(mapper.map('Hiî - ÏÍjkL'), 'hiî - ïíjkl');
+    });
+    test('testToLower_af_NA1', () {
+      final ILibCaseMapper mapper =
+          ILibCaseMapper(direction: 'tolower', locale: 'af-NA');
+      expect(mapper.map('AÁÄBCDEÊËÉÈFG'), 'aáäbcdeêëéèfg');
+    });
+    test('testToLower_af_NA2', () {
+      final ILibCaseMapper mapper =
+          ILibCaseMapper(direction: 'tolower', locale: 'af-NA');
+      expect(mapper.map('HIÎÏÍJKLMNOÔÖÓPQRSTUÛÜÚVWXYZ'),
+          'hiîïíjklmnoôöópqrstuûüúvwxyz');
+    });
+    test('testToLowerMixed_af_NA3', () {
+      final ILibCaseMapper mapper =
+          ILibCaseMapper(direction: 'tolower', locale: 'af-NA');
+      expect(mapper.map('Hiî - ÏÍjkL'), 'hiî - ïíjkl');
+    });
+    /*Hausa */
+    test('testToLower_ha_GH1', () {
+      final ILibCaseMapper mapper =
+          ILibCaseMapper(direction: 'tolower', locale: 'ha-GH');
+      expect(mapper.map('ABƁCDƊEFGHIJKƘLMNORSTUWYƳZ'),
+          'abɓcdɗefghijkƙlmnorstuwyƴz');
+    });
+    test('testToLower_ha_NE1', () {
+      final ILibCaseMapper mapper =
+          ILibCaseMapper(direction: 'tolower', locale: 'ha-NE');
+      expect(mapper.map('ABƁCDƊEFGHIJKƘLMNORSTUWYƳZ'),
+          'abɓcdɗefghijkƙlmnorstuwyƴz');
+    });
+    test('testToLower_ha_NG1', () {
+      final ILibCaseMapper mapper =
+          ILibCaseMapper(direction: 'tolower', locale: 'ha-NG');
+      expect(mapper.map('ABƁCDƊEFGHIJKƘLMNORSTUWYƳZ'),
+          'abɓcdɗefghijkƙlmnorstuwyƴz');
+    });
+  });
+}

--- a/test/casemapper/upper_test.dart
+++ b/test/casemapper/upper_test.dart
@@ -39,7 +39,7 @@ void main() {
 
     test('testToUpperFromPunctuationUnchanged_default', () {
       final ILibCaseMapper mapper = ILibCaseMapper();
-      expect(mapper.map('!@#\$%^&*()'), '!@#\$%^&*()');
+      expect(mapper.map(r'!@#\$%^&*()'), r'!@#\$%^&*()');
     });
 
     test('testToUpperFromNonLatinUnchanged_default', () {

--- a/test/casemapper/upper_test.dart
+++ b/test/casemapper/upper_test.dart
@@ -1,0 +1,243 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_ilib/flutter_ilib.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  debugPrint('Testing [upper_test.dart] file.');
+
+  group('ILibCaseMapper-upper', () {
+    test('testToUpperFromLower_default', () {
+      final ILibCaseMapper mapper = ILibCaseMapper();
+      expect(mapper.map('this is a string'), 'THIS IS A STRING');
+    });
+
+    test('testToUpperFromUpper_default', () {
+      final ILibCaseMapper mapper = ILibCaseMapper();
+      expect(mapper.map('THIS IS A STRING'), 'THIS IS A STRING');
+    });
+
+    test('testToUpperFromMixed_default', () {
+      final ILibCaseMapper mapper = ILibCaseMapper();
+      expect(mapper.map('This is a String'), 'THIS IS A STRING');
+    });
+
+    test('testToUpperFromLowerExplicitDirection_default', () {
+      final ILibCaseMapper mapper = ILibCaseMapper();
+      expect(mapper.map('this is a string'), 'THIS IS A STRING');
+    });
+
+    test('testToUpperFromUpperExplicitDirection_default', () {
+      final ILibCaseMapper mapper = ILibCaseMapper();
+      expect(mapper.map('THIS IS A STRING'), 'THIS IS A STRING');
+    });
+
+    test('testToUpperFromMixedExplicitDirection_default', () {
+      final ILibCaseMapper mapper = ILibCaseMapper();
+      expect(mapper.map('This is a String'), 'THIS IS A STRING');
+    });
+
+    test('testToUpperFromPunctuationUnchanged_default', () {
+      final ILibCaseMapper mapper = ILibCaseMapper();
+      expect(mapper.map('!@#\$%^&*()'), '!@#\$%^&*()');
+    });
+
+    test('testToUpperFromNonLatinUnchanged_default', () {
+      final ILibCaseMapper mapper = ILibCaseMapper();
+      expect(mapper.map('演蟻人 道格拉斯最老英雄'), '演蟻人 道格拉斯最老英雄');
+    });
+
+    test('testToUpperFromExtendedLatin_default', () {
+      final ILibCaseMapper mapper = ILibCaseMapper();
+      expect(mapper.map('ãéìôü'), 'ÃÉÌÔÜ');
+    });
+
+    test('testToUpperCyrillic_default', () {
+      final ILibCaseMapper mapper = ILibCaseMapper();
+      expect(mapper.map('празл'), 'ПРАЗЛ');
+    });
+
+    test('testToUpperGreek_default', () {
+      final ILibCaseMapper mapper = ILibCaseMapper();
+      expect(mapper.map('αβγδεζηθ'), 'ΑΒΓΔΕΖΗΘ');
+    });
+
+    test('testToUpperGreekSigma_default', () {
+      final ILibCaseMapper mapper = ILibCaseMapper();
+      expect(mapper.map('ιασας ιασας'), 'ΙΑΣΑΣ ΙΑΣΑΣ');
+    });
+
+    test('testToUpperCoptic_default', () {
+      final ILibCaseMapper mapper = ILibCaseMapper();
+      expect(mapper.map('ⲁⲃⲅⲇⲉⲋⲍⲏⲑⲓⲕⲗ'), 'ⲀⲂⲄⲆⲈⲊⲌⲎⲐⲒⲔⲖ');
+    });
+
+    test('testToUpperArmenian_default', () {
+      final ILibCaseMapper mapper = ILibCaseMapper();
+      expect(mapper.map('աբգդեզէըթ'), 'ԱԲԳԴԵԶԷԸԹ');
+    });
+
+    test('testToUpperGeorgian_default', () {
+      final ILibCaseMapper mapper = ILibCaseMapper();
+      expect(mapper.map('ⴀⴁⴂⴃⴄⴅⴆⴇⴈⴉ'), 'ႠႡႢႣႤႥႦႧႨႩ');
+    });
+
+    /* Azeri tests */
+    test('testToUpper_az_AZ', () {
+      final ILibCaseMapper mapper =
+          ILibCaseMapper(locale: 'az-AZ', direction: 'toupper');
+      expect(mapper.map('ıi'), 'Iİ');
+    });
+
+    /* Turkish tests */
+    test('testToUpper_tr_TR', () {
+      final ILibCaseMapper mapper =
+          ILibCaseMapper(locale: 'tr-TR', direction: 'toupper');
+      expect(mapper.map('ıi'), 'Iİ');
+    });
+
+    /* Crimean Tatar tests */
+    test('testToUpper_crh_Latn_UK', () {
+      final ILibCaseMapper mapper =
+          ILibCaseMapper(locale: 'crh-Latn-UK', direction: 'toupper');
+      expect(mapper.map('ıi'), 'Iİ');
+    });
+
+    /* Kazakh tests */
+    test('testToUpper_kk_Latn_KK', () {
+      final ILibCaseMapper mapper =
+          ILibCaseMapper(locale: 'kk-Latn-KK', direction: 'toupper');
+      expect(mapper.map('ıi'), 'Iİ');
+    });
+
+    /* Tatar tests */
+    test('testToUpper_tt_Latn_RU', () {
+      final ILibCaseMapper mapper =
+          ILibCaseMapper(locale: 'tt-Latn-RU', direction: 'toupper');
+      expect(mapper.map('ıi'), 'Iİ');
+    });
+
+    /* Karachay-Balkar tests */
+    test('testToUpper_krc_Latn_RU', () {
+      final ILibCaseMapper mapper =
+          ILibCaseMapper(locale: 'krc-Latn-RU', direction: 'toupper');
+      expect(mapper.map('ıi'), 'Iİ');
+    });
+
+    /* German tests */
+    test('testToUpper_de_DE', () {
+      final ILibCaseMapper mapper =
+          ILibCaseMapper(locale: 'de-DE', direction: 'toupper');
+      expect(mapper.map('groß'), 'GROSS');
+    });
+
+    /* Russian tests */
+    test('testToUpperLowerPalochka_ru_RU', () {
+      final ILibCaseMapper mapper =
+          ILibCaseMapper(locale: 'ru-RU', direction: 'toupper');
+      expect(mapper.map('ӏ'), 'Ӏ');
+    });
+
+    test('testToUpperUpperPalochka_ru_RU', () {
+      final ILibCaseMapper mapper =
+          ILibCaseMapper(locale: 'ru-RU', direction: 'toupper');
+      expect(mapper.map('Ӏ'), 'Ӏ');
+    });
+
+    /* Greek tests */
+    test('testToUpper_el_GR', () {
+      final ILibCaseMapper mapper =
+          ILibCaseMapper(locale: 'el-GR', direction: 'toupper');
+      expect(mapper.map('ιασας ιασας'), 'ΙΑΣΑΣ ΙΑΣΑΣ');
+    });
+
+    test('testToUpperAccents_el_GR', () {
+      final ILibCaseMapper mapper =
+          ILibCaseMapper(locale: 'el-GR', direction: 'toupper');
+      expect(mapper.map('άέήίΰϊϋόύώΐ'), 'ΑΕΗΙΥΙΥΟΥΩΙ');
+    });
+
+    /* French tests */
+    test('testToUpper_fr_FR', () {
+      final ILibCaseMapper mapper =
+          ILibCaseMapper(locale: 'fr-FR', direction: 'toupper');
+      expect(mapper.map('Tête-à-tête'), 'TÊTE-À-TÊTE');
+    });
+
+    /* French Canadian tests */
+    test('testToUpper_fr_CA', () {
+      final ILibCaseMapper mapper =
+          ILibCaseMapper(locale: 'fr-CA', direction: 'toupper');
+      expect(mapper.map('Tête-à-tête'), 'TÊTE-À-TÊTE');
+    });
+
+    // make sure it is not broken in Lithuanian
+    test('testToUpper_lt', () {
+      final ILibCaseMapper mapper =
+          ILibCaseMapper(locale: 'lt-LT', direction: 'toupper');
+      expect(mapper.map('aąbcčdeęėfghiįyjklmnoprsštuųūvzž'),
+          'AĄBCČDEĘĖFGHIĮYJKLMNOPRSŠTUŲŪVZŽ');
+    });
+
+    /*Afrikaans Test cases*/
+    test('testToUpper_af_ZA1', () {
+      final ILibCaseMapper mapper =
+          ILibCaseMapper(locale: 'af-ZA', direction: 'toupper');
+      expect(mapper.map('aáäbcdeêëéèfg'), 'AÁÄBCDEÊËÉÈFG');
+    });
+
+    test('testToUpper_af_ZA2', () {
+      final ILibCaseMapper mapper =
+          ILibCaseMapper(locale: 'af-ZA', direction: 'toupper');
+      expect(mapper.map('hiîïíjklmnoôöópqrstuûüúvwxyz'),
+          'HIÎÏÍJKLMNOÔÖÓPQRSTUÛÜÚVWXYZ');
+    });
+
+    test('testToUpperMixed_af_ZA3', () {
+      final ILibCaseMapper mapper =
+          ILibCaseMapper(locale: 'af-ZA', direction: 'toupper');
+      expect(mapper.map('hiî - ïíjkl'), 'HIÎ - ÏÍJKL');
+    });
+
+    test('testToUpper_af_NA1', () {
+      final ILibCaseMapper mapper =
+          ILibCaseMapper(locale: 'af-NA', direction: 'toupper');
+      expect(mapper.map('aáäbcdeêëéèfg'), 'AÁÄBCDEÊËÉÈFG');
+    });
+
+    test('testToUpper_af_NA2', () {
+      final ILibCaseMapper mapper =
+          ILibCaseMapper(locale: 'af-NA', direction: 'toupper');
+      expect(mapper.map('hiîïíjklmnoôöópqrstuûüúvwxyz'),
+          'HIÎÏÍJKLMNOÔÖÓPQRSTUÛÜÚVWXYZ');
+    });
+
+    test('testToUpperMixed_af_NA3', () {
+      final ILibCaseMapper mapper =
+          ILibCaseMapper(locale: 'af-NA', direction: 'toupper');
+      expect(mapper.map('hiî - ïíjkl'), 'HIÎ - ÏÍJKL');
+    });
+
+    /*Hausa */
+    test('testToUpper_ha_GH1', () {
+      final ILibCaseMapper mapper =
+          ILibCaseMapper(locale: 'ha-GH', direction: 'toupper');
+      expect(mapper.map('abɓcdɗefghijkƙlmnorstuwyƴz'),
+          'ABƁCDƊEFGHIJKƘLMNORSTUWYƳZ');
+    });
+
+    test('testToUpper_ha_NE1', () {
+      final ILibCaseMapper mapper =
+          ILibCaseMapper(locale: 'ha-NE', direction: 'toupper');
+      expect(mapper.map('abɓcdɗefghijkƙlmnorstuwyƴz'),
+          'ABƁCDƊEFGHIJKƘLMNORSTUWYƳZ');
+    });
+
+    test('testToUpper_ha_NG1', () {
+      final ILibCaseMapper mapper =
+          ILibCaseMapper(locale: 'ha-NG', direction: 'toupper');
+      expect(mapper.map('abɓcdɗefghijkƙlmnorstuwyƴz'),
+          'ABƁCDƊEFGHIJKƘLMNORSTUWYƳZ');
+    });
+  });
+}


### PR DESCRIPTION
### Checklist

The following lists affects Pub Points on pub.dev when the package is published.
* [x] Passed the all tests.
* [x] Verified that the example app works.
* [x] Executed the `dart format` command.
* [x] Added the API description is added if necessary.

### Description
* Implement `ILibCasemapper`
  *  It maps strings to upper or lower case. This mapping will work for any string as characters that have no case will be returned unchanged. 
  * Usage:
```
final ILibCaseMapper mapper = ILibCaseMapper(locale: 'tr-TR');
mapper.map('ıi');
// 'Iİ'
final ILibCaseMapper mapper = ILibCaseMapper(
    locale: 'tr-TR', direction: 'tolower');
mapper.map('Iİ');
// 'ıi'
```