### PR TITLE
[migration/ilib-js-to-dart] Call initILib() inside loadJSON and add asset manifest pre-check to skip unnecessary file load attempts

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -57,14 +57,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.3"
-  ffi:
-    dependency: transitive
-    description:
-      name: ffi
-      sha256: "7bf0adc28a23d395f19f3f1eb21dd7cfd1dd9f8e1c50051c069122e6853bc878"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.0"
   file:
     dependency: transitive
     description:
@@ -89,15 +81,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.8.0"
-  flutter_js:
-    dependency: transitive
-    description:
-      name: flutter_js
-      sha256: d19cde4bad2f7c301ff5f69d7b3452ff91f2ca89d153569dd03e544579d8610d
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.8.1"
+    version: "2.0.0"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -116,22 +100,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  http:
-    dependency: transitive
-    description:
-      name: http
-      sha256: "759d1a329847dd0f39226c688d3e06a6b8679668e350e2891a6474f8b4bb8525"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.0"
-  http_parser:
-    dependency: transitive
-    description:
-      name: http_parser
-      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.0.2"
   integration_test:
     dependency: "direct dev"
     description: flutter
@@ -294,14 +262,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.4"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      sha256: facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.3.2"
   vector_math:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -57,6 +57,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.3"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      sha256: "7bf0adc28a23d395f19f3f1eb21dd7cfd1dd9f8e1c50051c069122e6853bc878"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   file:
     dependency: transitive
     description:
@@ -81,7 +89,15 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.0"
+    version: "1.8.0"
+  flutter_js:
+    dependency: transitive
+    description:
+      name: flutter_js
+      sha256: d19cde4bad2f7c301ff5f69d7b3452ff91f2ca89d153569dd03e544579d8610d
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.1"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -100,6 +116,22 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  http:
+    dependency: transitive
+    description:
+      name: http
+      sha256: "759d1a329847dd0f39226c688d3e06a6b8679668e350e2891a6474f8b4bb8525"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
+  http_parser:
+    dependency: transitive
+    description:
+      name: http_parser
+      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.2"
   integration_test:
     dependency: "direct dev"
     description: flutter
@@ -262,6 +294,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.4"
+  typed_data:
+    dependency: transitive
+    description:
+      name: typed_data
+      sha256: facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.2"
   vector_math:
     dependency: transitive
     description:

--- a/lib/ilib_init.dart
+++ b/lib/ilib_init.dart
@@ -27,6 +27,8 @@ class ILibLoader extends ChangeNotifier {
   final Map<String, Map<String, dynamic>> _fileDataCache =
       <String, Map<String, dynamic>>{};
 
+  final Set<String> _availableAssets = <String>{};
+
   Map<String, dynamic>? getLocaleData(String locale) {
     return _localeDataMap[locale] ?? _mergeFromCache(locale);
   }
@@ -47,9 +49,29 @@ class ILibLoader extends ChangeNotifier {
     return null;
   }
 
+  Future<void> _loadAssetManifest() async {
+    if (_availableAssets.isNotEmpty) {
+      return;
+    }
+    try {
+      final String manifestContent =
+          await rootBundle.loadString('AssetManifest.json');
+      final Map<String, dynamic> manifest =
+          json.decode(manifestContent) as Map<String, dynamic>;
+      _availableAssets.addAll(manifest.keys);
+    } catch (err) {
+      logger.error('Failed to load AssetManifest.json: $err');
+    }
+  }
+
   Future<Map<String, dynamic>?> _loadFile(String path) async {
     if (_fileDataCache.containsKey(path)) {
       return _fileDataCache[path];
+    }
+    if (_availableAssets.isNotEmpty &&
+        !_availableAssets.contains(path) &&
+        !_availableAssets.contains(path.replaceFirst('packages/flutter_ilib/', ''))) {
+      return null;
     }
     try {
       final String content = await rootBundle.loadString(path);
@@ -60,8 +82,7 @@ class ILibLoader extends ChangeNotifier {
     } on FormatException catch (err) {
       logger.error('Invalid JSON format in $path: $err');
       return null;
-    } catch (err) {
-      logger.info('Locale data file not available, skipping: $path');
+    } catch (_) {
       return null;
     }
   }
@@ -105,13 +126,19 @@ class ILibLoader extends ChangeNotifier {
   }
 
   Future<void> loadJSON() async {
+    await _loadAssetManifest();
+
+    // Always load root.json first as it contains locale-independent data (e.g. astro)
+    await _loadFile('packages/flutter_ilib/assets/locale/root.json');
+
     final String curlocale = getLocale();
     if (isValidLocale(curlocale)) {
       await _loadLocaleData(curlocale);
     } else {
-      logger.warn('Invalid locale: $curlocale, no data loaded');
+      logger.warn('Invalid locale: $curlocale, no locale-specific data loaded');
     }
 
+    initILib();
     logger.info('Notifying listeners after JSON loading');
     notifyListeners();
   }

--- a/test/datefmt/datefmt_af_ZA_test.dart
+++ b/test/datefmt/datefmt_af_ZA_test.dart
@@ -8,7 +8,6 @@ void main() {
   debugPrint('Testing [datefmt_af_ZA_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('af-ZA');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_am_ET_test.dart
+++ b/test/datefmt/datefmt_am_ET_test.dart
@@ -11,7 +11,6 @@ void main() {
   setUpAll(() async {
     testPlatform = getTestPlatform();
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('am-ET');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_ar_EG_test.dart
+++ b/test/datefmt/datefmt_ar_EG_test.dart
@@ -11,7 +11,6 @@ void main() {
   setUpAll(() async {
     testPlatform = getTestPlatform();
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('ar-EG');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_ar_SA_test.dart
+++ b/test/datefmt/datefmt_ar_SA_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_ar_SA_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('ar-SA');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_as_IN_test.dart
+++ b/test/datefmt/datefmt_as_IN_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_as_IN_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('as-IN');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_az_Latn_AZ_test.dart
+++ b/test/datefmt/datefmt_az_Latn_AZ_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_az_Latn_AZ_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('az-Latn-AZ');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_bg_test.dart
+++ b/test/datefmt/datefmt_bg_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_bg_BG_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('bg-BG');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_bn_IN_test.dart
+++ b/test/datefmt/datefmt_bn_IN_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_bn_IN_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('bn-IN');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_bs_Latn_BA_test.dart
+++ b/test/datefmt/datefmt_bs_Latn_BA_test.dart
@@ -11,7 +11,6 @@ void main() {
   setUpAll(() async {
     testPlatform = getTestPlatform();
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('bs-Latn-BA');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_cs_CZ_test.dart
+++ b/test/datefmt/datefmt_cs_CZ_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_cs_CZ_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('cs-CZ');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_da_DK_test.dart
+++ b/test/datefmt/datefmt_da_DK_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_da_DK_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('da-DK');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_de_DE_test.dart
+++ b/test/datefmt/datefmt_de_DE_test.dart
@@ -11,7 +11,6 @@ void main() {
   setUpAll(() async {
     testPlatform = getTestPlatform();
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('de-DE');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_el_GR_test.dart
+++ b/test/datefmt/datefmt_el_GR_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_el_GR_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('el-GR');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_en_AU_test.dart
+++ b/test/datefmt/datefmt_en_AU_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_en_AU_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('en-AU');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_en_CA_test.dart
+++ b/test/datefmt/datefmt_en_CA_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_en_CA_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('en-CA');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_en_GB_test.dart
+++ b/test/datefmt/datefmt_en_GB_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_en_GB_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('en-GB');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_en_HK_test.dart
+++ b/test/datefmt/datefmt_en_HK_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_en_HK_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('en-HK');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_en_IE_test.dart
+++ b/test/datefmt/datefmt_en_IE_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_en_IE_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('en-IE');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_en_IN_test.dart
+++ b/test/datefmt/datefmt_en_IN_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_en_IN_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('en-IN');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_en_KE_test.dart
+++ b/test/datefmt/datefmt_en_KE_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_en_KE_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('en-KE');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_en_MY_test.dart
+++ b/test/datefmt/datefmt_en_MY_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_en_MY_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('en-MY');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_en_NZ_test.dart
+++ b/test/datefmt/datefmt_en_NZ_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_en_NZ_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('en-NZ');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_en_SG_test.dart
+++ b/test/datefmt/datefmt_en_SG_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_en_SG_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('en-SG');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_en_US_test.dart
+++ b/test/datefmt/datefmt_en_US_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_en_US_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('en-US');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_en_ZA_test.dart
+++ b/test/datefmt/datefmt_en_ZA_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_en_ZA_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('en-ZA');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_es_CO_test.dart
+++ b/test/datefmt/datefmt_es_CO_test.dart
@@ -11,7 +11,6 @@ void main() {
   setUpAll(() async {
     testPlatform = getTestPlatform();
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('es-CO');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_es_ES_test.dart
+++ b/test/datefmt/datefmt_es_ES_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_es_ES_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('es-ES');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_es_MX_test.dart
+++ b/test/datefmt/datefmt_es_MX_test.dart
@@ -11,7 +11,6 @@ void main() {
   setUpAll(() async {
     testPlatform = getTestPlatform();
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('es-MX');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_es_US_test.dart
+++ b/test/datefmt/datefmt_es_US_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_es_US_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('es-US');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_et_EE_test.dart
+++ b/test/datefmt/datefmt_et_EE_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_et_EE_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('et-EE');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_fa_IR_test.dart
+++ b/test/datefmt/datefmt_fa_IR_test.dart
@@ -11,7 +11,6 @@ void main() {
   setUpAll(() async {
     testPlatform = getTestPlatform();
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('fa-IR');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_fi_FI_test.dart
+++ b/test/datefmt/datefmt_fi_FI_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_fi_FI_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('fi-FI');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_fr_CA_test.dart
+++ b/test/datefmt/datefmt_fr_CA_test.dart
@@ -11,7 +11,6 @@ void main() {
   setUpAll(() async {
     testPlatform = getTestPlatform();
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('fr-CA');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_fr_FR_test.dart
+++ b/test/datefmt/datefmt_fr_FR_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_fr_FR_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('fr-FR');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_ga_IE_test.dart
+++ b/test/datefmt/datefmt_ga_IE_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_ga_IE_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('ga-IE');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_gu_IN_test.dart
+++ b/test/datefmt/datefmt_gu_IN_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_gu_IN_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('gu-IN');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_ha_Latn_NG_test.dart
+++ b/test/datefmt/datefmt_ha_Latn_NG_test.dart
@@ -11,7 +11,6 @@ void main() {
   setUpAll(() async {
     testPlatform = getTestPlatform();
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('ha-Latn-NG');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_he_IL_test.dart
+++ b/test/datefmt/datefmt_he_IL_test.dart
@@ -11,7 +11,6 @@ void main() {
   setUpAll(() async {
     testPlatform = getTestPlatform();
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('he-IL');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_hi_IN_test.dart
+++ b/test/datefmt/datefmt_hi_IN_test.dart
@@ -11,7 +11,6 @@ void main() {
   setUpAll(() async {
     testPlatform = getTestPlatform();
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('hi-IN');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_hr_HR_test.dart
+++ b/test/datefmt/datefmt_hr_HR_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_hr_HR_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('hr-HR');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_id_ID_test.dart
+++ b/test/datefmt/datefmt_id_ID_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_id_ID_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('id-ID');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_it_IT_test.dart
+++ b/test/datefmt/datefmt_it_IT_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_it_IT_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('it-IT');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_ja_JP_test.dart
+++ b/test/datefmt/datefmt_ja_JP_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_ja_JP_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('ja-JP');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_ka_GE_test.dart
+++ b/test/datefmt/datefmt_ka_GE_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_ka_GE_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('ka-GE');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_kk_Cyrl_KZ_test.dart
+++ b/test/datefmt/datefmt_kk_Cyrl_KZ_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_kk_Cyrl_KZ_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('kk-Cyrl-KZ');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_km_KH_test.dart
+++ b/test/datefmt/datefmt_km_KH_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_km_KH_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('km-KH');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_kn_IN_test.dart
+++ b/test/datefmt/datefmt_kn_IN_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_kn_IN_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('kn-IN');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_ko_KR_test.dart
+++ b/test/datefmt/datefmt_ko_KR_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_ko_KR_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('ko-KR');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_ku_Arab_IQ_test.dart
+++ b/test/datefmt/datefmt_ku_Arab_IQ_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_ku_Arab_IQ_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('ku-Arab-IQ');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_lt_LT_test.dart
+++ b/test/datefmt/datefmt_lt_LT_test.dart
@@ -11,7 +11,6 @@ void main() {
   setUpAll(() async {
     testPlatform = getTestPlatform();
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('lt-LT');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_lv_LV_test.dart
+++ b/test/datefmt/datefmt_lv_LV_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_lv_LV_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('lv-LV');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_mk_MK_test.dart
+++ b/test/datefmt/datefmt_mk_MK_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_mk_MK_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('mk-MK');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_ml_IN_test.dart
+++ b/test/datefmt/datefmt_ml_IN_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_ml_IN_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('ml-IN');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_mn_Cyrl_MN_test.dart
+++ b/test/datefmt/datefmt_mn_Cyrl_MN_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_mn_Cyrl_MN_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('mn-Cyrl-MN');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_mr_IN_test.dart
+++ b/test/datefmt/datefmt_mr_IN_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_mr_IN_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('mr-IN');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_ms_MY_test.dart
+++ b/test/datefmt/datefmt_ms_MY_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_ms_MY_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('ms-MY');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_nb_NO_test.dart
+++ b/test/datefmt/datefmt_nb_NO_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_nb_NO_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('nb-NO');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_nl_NL_test.dart
+++ b/test/datefmt/datefmt_nl_NL_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_nl_NL_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('nl-NL');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_or_IN_test.dart
+++ b/test/datefmt/datefmt_or_IN_test.dart
@@ -11,7 +11,6 @@ void main() {
   setUpAll(() async {
     testPlatform = getTestPlatform();
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('or-IN');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_pa_IN_test.dart
+++ b/test/datefmt/datefmt_pa_IN_test.dart
@@ -11,7 +11,6 @@ void main() {
   setUpAll(() async {
     testPlatform = getTestPlatform();
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('pa-IN');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_pl_PL_test.dart
+++ b/test/datefmt/datefmt_pl_PL_test.dart
@@ -11,7 +11,6 @@ void main() {
   setUpAll(() async {
     testPlatform = getTestPlatform();
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('pl-PL');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_pt_BR_test.dart
+++ b/test/datefmt/datefmt_pt_BR_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_pt_BR_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('pt-BR');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_pt_PT_test.dart
+++ b/test/datefmt/datefmt_pt_PT_test.dart
@@ -11,7 +11,6 @@ void main() {
   setUpAll(() async {
     testPlatform = getTestPlatform();
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('pt-PT');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_ro_RO_test.dart
+++ b/test/datefmt/datefmt_ro_RO_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_ro_RO_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('ro-RO');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_ru_RU_test.dart
+++ b/test/datefmt/datefmt_ru_RU_test.dart
@@ -11,7 +11,6 @@ void main() {
   setUpAll(() async {
     testPlatform = getTestPlatform();
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('ru-RU');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_si_LK_test.dart
+++ b/test/datefmt/datefmt_si_LK_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_si_LK_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('si-LK');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_sk_SK_test.dart
+++ b/test/datefmt/datefmt_sk_SK_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_sk_SK_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('sk-SK');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_sl_SI_test.dart
+++ b/test/datefmt/datefmt_sl_SI_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_sl_SI_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('sl-SI');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_sq_AL_test.dart
+++ b/test/datefmt/datefmt_sq_AL_test.dart
@@ -11,7 +11,6 @@ void main() {
   setUpAll(() async {
     testPlatform = getTestPlatform();
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('sq-AL');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_sr_Latn_RS_test.dart
+++ b/test/datefmt/datefmt_sr_Latn_RS_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_sr_Latn_RS_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('sr-Latn-RS');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_sv_SE_test.dart
+++ b/test/datefmt/datefmt_sv_SE_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_sv_SE_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('sv-SE');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_sw_KE_test.dart
+++ b/test/datefmt/datefmt_sw_KE_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_sw_KE_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('sw-KE');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_ta_IN_test.dart
+++ b/test/datefmt/datefmt_ta_IN_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_ta_IN_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('ta-IN');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_te_IN_test.dart
+++ b/test/datefmt/datefmt_te_IN_test.dart
@@ -11,7 +11,6 @@ void main() {
   setUpAll(() async {
     testPlatform = getTestPlatform();
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('te-IN');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_th_TH_test.dart
+++ b/test/datefmt/datefmt_th_TH_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_th_TH_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('th-TH');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_tr_TR_test.dart
+++ b/test/datefmt/datefmt_tr_TR_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_tr_TR_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('tr-TR');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_uk_UA_test.dart
+++ b/test/datefmt/datefmt_uk_UA_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_uk_UA_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('uk-UA');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_ur_IN_test.dart
+++ b/test/datefmt/datefmt_ur_IN_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_ur_IN_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('ur-IN');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_uz_Latn_UZ_test.dart
+++ b/test/datefmt/datefmt_uz_Latn_UZ_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_uz_Latn_UZ_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('uz-Latn-UZ');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_vi_VN_test.dart
+++ b/test/datefmt/datefmt_vi_VN_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_vi_VN_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('vi-VN');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_zh_CN_test.dart
+++ b/test/datefmt/datefmt_zh_CN_test.dart
@@ -7,7 +7,6 @@ void main() {
   debugPrint('Testing [datefmt_zh_CN_test.dart] file.');
   setUpAll(() async {
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('zh-Hans-CN');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_zh_Hant_HK_test.dart
+++ b/test/datefmt/datefmt_zh_Hant_HK_test.dart
@@ -11,7 +11,6 @@ void main() {
   setUpAll(() async {
     testPlatform = getTestPlatform();
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('zh-Hant-HK');
   });
   group('format()', () {

--- a/test/datefmt/datefmt_zh_Hant_TW_test.dart
+++ b/test/datefmt/datefmt_zh_Hant_TW_test.dart
@@ -11,7 +11,6 @@ void main() {
   setUpAll(() async {
     testPlatform = getTestPlatform();
     await ILibLoader.instance.loadJSON();
-    ILibLoader.instance.initILib();
     await ILibLoader.instance.loadILibLocaleData('zh-Hant-TW');
   });
   group('format()', () {


### PR DESCRIPTION
### Checklist

The following lists affects Pub Points on pub.dev when the package is published.
* [ ] Passed the all tests.
* [ ] Verified that the example app works.
* [ ] Executed the `dart format` command.
* [ ] Added the API description is added if necessary.

### Description
* Asset manifest pre-check to skip unnecessary file load attempts
* Call initILib() inside loadJSON() and always load root.json
  *  loadJSON() now always loads root.json first, ensuring locale-independent data (e.g. ilib.data.astro) is available regardless of locale validity
  *  loadJSON() calls initILib() automatically before notifying listeners, so callers no longer need to call initILib() separately
  * Remove redundant initILib() calls from all test files