### PR TITLE
[migration/ilib-js-to-dart] Implement ILibNumFmt in dart

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Install Linux desktop dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          clang \
+          cmake \
+          libgtk-3-dev \
+          liblzma-dev \
+          ninja-build \
+          pkg-config \
+          xvfb
     - uses: subosito/flutter-action@v2
     - run: flutter --version
     - run: ./execute_unit_test.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * Add system `'local'` timezone support (DST-aware, sampled from the OS). An omitted timezone now
   defaults to `'local'`, matching iLib JS; `'local'` and `'Etc/UTC'` therefore differ on a non-UTC
   host.
-* Based on iLib v14.21.0 / CLDR 48.2.
+* Based on iLib v14.22.0 / CLDR 48.2.
 * **Breaking**: `ILibCountry`, `ILibScriptInfo`, `ILibNumFmt`, and `ILibDurationFmt` are not yet
   ported to pure Dart and are unavailable in this release; they are planned for a later 2.x.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,7 @@ Options → ILibLocaleInfo (determines locale, calendar, clock, meridiems)
 | 9 calendars | `lib/calendar/{name}_date.dart` + `{name}_rata_die.dart` | gregorian, thaisolar, julian, islamic, hebrew, ethiopic, coptic, persian (astronomical), persian-algo (algorithmic) — see [docs/date-calendar-architecture.md](docs/date-calendar-architecture.md) |
 | ILibAstro | `lib/calendar/ilib_astro.dart` | Astronomical calculation (`ilib.data.astro`) |
 | ILibDateOptions | `lib/ilib_date.dart` | `_toCalendarDate()` delegates per calendar |
+| ILibNumFmt | `lib/ilib_numfmt.dart` | `ilib.data.localeinfo.numfmt` + `ilib.data.currency` |
 
 ### Not yet ported (currently non-functional)
 The `ILibJS` interop bridge was removed in v2.0, but these classes were never converted to pure
@@ -62,7 +63,6 @@ not compile and are not exported** from `flutter_ilib.dart`. Porting them is the
 | ILibCountry | `lib/ilib_country.dart` | 5 |
 | ILibScriptInfo | `lib/ilib_scriptinfo.dart` | 7 |
 | ILibDurationFmt | `lib/ilib_durationfmt.dart` | 4 |
-| ILibNumFmt | `lib/ilib_numfmt.dart` | 12 |
 
 ## Conversion Pattern (How to Convert a Class)
 See [docs/conversion-guide.md](docs/conversion-guide.md) for the full checklist (analyze JS source →
@@ -124,7 +124,7 @@ lib/
 ├── ilib_casemapper.dart        # case conversion
 ├── ilib_country.dart           # [unconverted] country info
 ├── ilib_durationfmt.dart       # [unconverted] duration format
-├── ilib_numfmt.dart            # [unconverted] number format
+├── ilib_numfmt.dart            # number format
 ├── ilib_scriptinfo.dart        # [unconverted] script info
 ├── calendar/
 │   ├── rata_die.dart           # ILibRataDie abstract base (shared static methods)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,11 +9,11 @@ Reads JSON locale data directly and performs formatting/calculation in Dart.
 instead of repeating the numbers, so a version bump only changes the values here (plus the two
 point-in-time/public spots listed below).
 
-- **iLib JS source**: **v14.21.0** — all `lib/` Dart code and `test/` cases were converted
+- **iLib JS source**: **v14.22.0** — all `lib/` Dart code and `test/` cases were converted
   from the iLib JS at this tag (`js/lib/` and `js/test/` of github.com/iLib-js/iLib;
-  `git checkout v14.21.0`).
+  `git checkout v14.22.0`).
 - **CLDR data**: **48.2** — the bundled `assets/locale/` JSON (218 locales) was generated from
-  iLib v14.21.0, which incorporates CLDR 46.
+  iLib v14.22.0, which incorporates CLDR 46.
 - When updating to a newer iLib/CLDR: bump the JS source and the generated locale data
   **together** (a JS-only or data-only bump will diverge), then re-run the converted tests
   against the new JS expectations.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ locale information.
 > The change is internal only — the public API is the same across major versions, so your usage
 > code does not need to change when upgrading from v1.x to v2.0.
 
-The Dart implementation and the bundled locale data are based on **iLib v14.21.0** (which
+The Dart implementation and the bundled locale data are based on **iLib v14.22.0** (which
 incorporates **CLDR 48.2**).
 
 ## 📚 Documentation

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -93,6 +93,7 @@ If you're an AI agent (Claude, Copilot, etc.), follow this sequence:
 | [local-timezone-support.md](./local-timezone-support.md) | System `'local'` timezone — implemented (Strategy A) + optional Strategy B | Developers, AI |
 | [conversion-guide.md](./conversion-guide.md) | General JS→Dart conversion checklist | Developers |
 | [test-mapping.md](./test-mapping.md) | JS→Dart test file mapping, not-converted patterns | Developers, AI |
+| [benchmark.md](./benchmark.md) | Performance & memory: v2.0 (pure Dart) vs v1.3.0 (JS interop) + empty-app baseline | Developers, AI |
 | [numfmt-conversion-notes.md](./numfmt-conversion-notes.md) | NumFmt & MathUtils conversion gotchas (rounding, precision, API differences) | Developers, AI | ~200 lines |
 
 ### External Documentation

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -93,7 +93,7 @@ If you're an AI agent (Claude, Copilot, etc.), follow this sequence:
 | [local-timezone-support.md](./local-timezone-support.md) | System `'local'` timezone — implemented (Strategy A) + optional Strategy B | Developers, AI |
 | [conversion-guide.md](./conversion-guide.md) | General JS→Dart conversion checklist | Developers |
 | [test-mapping.md](./test-mapping.md) | JS→Dart test file mapping, not-converted patterns | Developers, AI |
-| [benchmark.md](./benchmark.md) | Performance & memory: v2.0 (pure Dart) vs v1.3.0 (JS interop) + empty-app baseline | Developers, AI |
+| [numfmt-conversion-notes.md](./numfmt-conversion-notes.md) | NumFmt & MathUtils conversion gotchas (rounding, precision, API differences) | Developers, AI | ~200 lines |
 
 ### External Documentation
 

--- a/docs/numfmt-conversion-notes.md
+++ b/docs/numfmt-conversion-notes.md
@@ -1,0 +1,224 @@
+# NumFmt & MathUtils Conversion Notes
+
+Gotchas, edge cases, and design decisions discovered during JS→Dart conversion.
+
+## MathUtils (math_utils.dart)
+
+### JS `Math.round` vs Dart Rounding Behavior
+
+| Scenario | JS `Math.round` | Dart `.round()` | Notes |
+|----------|----------------|-----------------|-------|
+| Positive tie (2.5) | 3 (toward +∞) | 3 (half-away-from-zero) | Same result |
+| Negative tie (-2.5) | **-2** (toward +∞) | **-3** (half-away-from-zero) | **Different!** |
+
+- JS `Math.round` is "half toward positive infinity" — ties always go toward +∞.
+- Dart `.round()` is "half away from zero" — ties go away from 0 (in both directions).
+- **Impact**: `roundHalfup` (ties away from zero) produces different results from JS `Math.round` for negative ties.
+
+### Solution: `roundHalfPositiveInfinity`
+
+A dedicated function mirrors the exact behavior of JS `Math.round`:
+
+```dart
+double roundHalfPositiveInfinity(double num) => (num + 0.5).floorToDouble();
+```
+
+When JS code uses `Math.round` as the default rounding function (e.g., in `significant()`
+without a third argument), pass `roundHalfPositiveInfinity` in Dart to get identical results.
+
+### `mod` / `amod` — int-only vs JS float-accepting
+
+JS `MathUtils.mod` accepts floats (`mod(2.234231, 4)` → `2.234231`).
+The Dart version is `int`-only — the project never uses float modulo.
+
+Note: `calendar_utils.dart` also has its own `mod` function (identical logic).
+NumFmt uses the one from `math_utils.dart`.
+
+### `signum` — Type Safety
+
+JS handles `typeof(num) === 'string'` (tries `parseInt`), and returns `1` for
+`undefined`, `null`, non-numeric strings, booleans, and functions.
+Dart version only accepts `num` type — the type system guarantees validity.
+
+### `shiftDecimal` — Floating-Point Precision
+
+JS:
+```javascript
+var numArray = ("" + number).split("e");
+return +(numArray[0] + "e" + (numArray[1] ? (+numArray[1] + precision) : precision));
+```
+
+Dart:
+```dart
+final List<String> parts = number.toString().split('e');
+final String base = parts[0];
+final int existingExp = parts.length > 1 ? int.parse(parts[1]) : 0;
+return double.parse('${base}e${existingExp + precision}');
+```
+
+Both use string-based "e" notation to avoid floating-point drift. Same strategy.
+
+---
+
+## NumFmt (ilib_numfmt.dart)
+
+### Architecture Differences
+
+| Aspect | JS (NumFmt.js) | Dart (ilib_numfmt.dart) |
+|--------|---------------|------------------------|
+| Data loading | `Utils.loadData()` + callback/sync | `ILibLoader.instance.getLocaleData()` |
+| Locale info | `new LocaleInfo(locale)` | `ILibLocaleInfo(locale)` |
+| Currency info | `new Currency({...})` | Direct access via `localeData['ilib.data.currency']` |
+| String substitution | `new IString(template).format(...)` | `String.replaceAll('{n}', ...)` |
+
+### No Separate Currency Class
+
+JS uses a separate `Currency` class (`Currency.js`) that loads currency data,
+provides methods like `getSign()`, `getFractionDigits()`, and `getRoundingMode()`,
+and supports searching currencies by sign (with circulation-based fallback).
+
+In Dart, **no separate `ILibCurrency` class exists**. Instead, `ILibNumFmt` accesses
+the JSON data directly:
+
+```dart
+final Map<String, dynamic>? localeData = ILibLoader.instance.getLocaleData(_locale);
+final Map<String, dynamic>? allCurrencies =
+    localeData?['ilib.data.currency'] as Map<String, dynamic>?;
+final Map<String, dynamic>? currInfo = allCurrencies?[_currencyCode];
+```
+
+The needed fields (`sign`, `decimals`, `roundingMode`) are extracted directly from
+the JSON map without wrapping them in a separate currency class.
+
+If future requirements need feature parity with JS `Currency` class (search by sign,
+list all currencies, etc.), then `ILibCurrency` should be implemented separately.
+
+### Default Rounding Mode
+
+- JS: `"halfdown"` (NumFmt.js:360) — `MathUtils["halfdown"]`
+- Dart: Same — `"halfdown"` as default
+- Currency type: the currency data's `roundingMode` field takes precedence
+
+### `constrain()` — Public API vs Internal
+
+JS `constrain(num)` is a public method that accepts an integer and returns the
+constrained result. Dart exposes `constrain(int)` publicly, while `_constrain(double)`
+is the internal workhorse called by `format()` to apply rounding/significant digits.
+
+### `_formatStandard` — `double.toString()` Artifact
+
+Dart `double.toString()` always appends `.0` for integer values:
+```dart
+(123.0).toString() == '123.0'  // fraction = '0'
+```
+
+In JS, `"" + 123` yields `"123"` — no fraction part.
+
+**Fix**: Treat fraction `'0'` as null when minFractionDigits is not set:
+
+```dart
+if (fraction == '0' &&
+    (_minFractionDigits == null || _minFractionDigits! <= 0) &&
+    (_maxFractionDigits == null || _maxFractionDigits! < 0)) {
+  fraction = null;
+}
+```
+
+### `_formatScientific` — Precision Loss Prevention
+
+The path `double.toStringAsExponential()` → `split('e')` → `double.parse(significand)` →
+`significant(...)` → `toString()` can lose the last significant digit due to
+IEEE 754 precision limits in unnecessary string↔double conversions.
+
+**Fix**: Only re-parse when constraints actually need rounding:
+
+```dart
+final bool needsConstraints =
+    (_maxFractionDigits != null && _maxFractionDigits! > 0) ||
+    (_significantDigits != null && _significantDigits! > 0);
+```
+
+### Negative Number Formatting
+
+Negative formatting uses a separate template:
+- `number` type: `negativeNumberFormat` from locale data (e.g., `"-{n}"`, `"({n})"`)
+- `currency` type: `currencyFormats.commonNegative` / `isoNegative`
+- `percentage` type: `negativePercentageFormat`
+
+`{n}` is always replaced with the absolute value of the formatted number.
+
+### Grouping — Primary + Secondary
+
+Indian-style numbers (12,34,56,789):
+- Primary group (rightmost): 3 digits
+- Secondary group (remaining): 2 digits each
+
+JS uses a `while` loop to apply secondary grouping repeatedly.
+Dart mirrors this in `_applySecondaryGrouping`.
+
+### Native Digits
+
+Determined by `useNative` option or locale's `digitsStyle`:
+- `digitsStyle == 'native'`: always use native digits
+- `digitsStyle == 'optional'` && `style == 'native'`: use native digits
+- Otherwise: Western digits (0-9)
+
+Native digit substitution maps codeUnits 48-57 (0-9) to characters from
+`localeInfo.getNativeDigits()` string by index.
+
+### Currency Sign Resolution
+
+1. `options.currency` → look up via `ilib.data.currency[code]`
+2. If `currInfo['sign']` exists, use it (e.g., `"$"`, `"€"`)
+3. Otherwise, use the ISO code itself as the sign
+4. `style == 'iso'` always forces the ISO code as sign
+
+### Exponential Symbol
+
+- Western default: `"e"`
+- Some locales: `"×10^"` etc.
+- When `useNative`: uses `localeInfo.getNativeExponential()`
+
+---
+
+## Test Conversion Notes
+
+### JS `test.roughlyEqual` → Dart `closeTo`
+
+JS approximate float comparison:
+```javascript
+test.roughlyEqual(actual, 2.234231, 0.0000001);
+```
+
+Dart equivalent:
+```dart
+expect(actual, closeTo(2.234231, 0.0000001));
+```
+
+Float mod/amod tests from JS are excluded (Dart version is int-only).
+
+### JS `undefined` vs Dart `null`
+
+- JS `typeof(this.maxFractionDigits) === 'undefined'` → Dart `_maxFractionDigits == null`
+- JS `typeof(options.significantDigits) !== 'undefined'` → Dart `options.significantDigits != null`
+- "Not set" state: JS uses `undefined`, Dart uses `null` uniformly
+
+### NumFmt Test Structure
+
+JS tests are split by locale:
+```
+js/test/testNumFmt.js          (basic English)
+js/test/testNumFmtAsync.js
+js/test/numprs/testnumfmt_*.js (per-locale)
+```
+
+Dart tests follow the same structure under `test/numfmt/`.
+
+---
+
+## References
+
+- JS source: `iLib/js/lib/NumFmt.js`, `iLib/js/lib/MathUtils.js`
+- JS tests: `iLib/js/test/util/testutils.js`, `iLib/js/test/testNumFmt*.js`
+- Dart source: `lib/ilib_numfmt.dart`, `lib/internal/math_utils.dart`
+- Dart tests: `test/basic/flutter_ilib_math_utils_test.dart`, `test/numfmt/`

--- a/example/integration_test/example_app_integration_test.dart
+++ b/example/integration_test/example_app_integration_test.dart
@@ -1,0 +1,258 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_ilib_example/main.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  const Duration localeTapVisualDelay = Duration(milliseconds: 700);
+
+  final List<String> testLocales = <String>[
+    'en-GB',
+    'en-US',
+    'de-DE',
+    'hi-IN',
+    'ko-KR',
+    'ru-RU',
+    'fa-IR',
+    'am-ET'
+  ];
+
+  final Map<String, String> expectedDateTimeValues = <String, String>{
+    'en-GB': '23 May 2026 at 16:30',
+    'en-US': 'May 23, 2026 at 4:30\u202FPM',
+    'de-DE': '23. Mai 2026 um 16:30',
+    'hi-IN': '23 मई 2026 को 4:30 pm बजे',
+    'ko-KR': '2026년 5월 23일 오후 4:30',
+    'ru-RU': '23 мая 2026\u202Fг. в 16:30',
+    'fa-IR': '\u200F1405 خرداد 2، ساعت \u200F16:30',
+    'am-ET': '15 ግንቦት 2018 10:30 ከሰዓት',
+  };
+
+  final Map<String, String> expectedFirstDayValues = <String, String>{
+    'en-GB': 'Monday',
+    'en-US': 'Sunday',
+    'de-DE': 'Monday',
+    'hi-IN': 'Sunday',
+    'ko-KR': 'Sunday',
+    'ru-RU': 'Monday',
+    'fa-IR': 'Saturday',
+    'am-ET': 'Sunday',
+  };
+
+  final Map<String, String> expectedClockValues = <String, String>{
+    'en-GB': '24',
+    'en-US': '12',
+    'de-DE': '24',
+    'hi-IN': '12',
+    'ko-KR': '12',
+    'ru-RU': '24',
+    'fa-IR': '24',
+    'am-ET': '12',
+  };
+
+  final Map<String, String> expectedNumberFormatValues = <String, String>{
+    'en-GB': '-111,123,456.785',
+    'en-US': '-111,123,456.785',
+    'de-DE': '-111.123.456,785',
+    'hi-IN': '-11,11,23,456.785',
+    'ko-KR': '-111,123,456.785',
+    'ru-RU': '-111\u00A0123\u00A0456,785',
+    'fa-IR': '\u200E−۱۱۱٬۱۲۳٬۴۵۶٫۷۸۵',
+    'am-ET': '-111,123,456.785',
+  };
+
+  final Map<String, String> expectedCountryValues = <String, String>{
+    'en-GB': 'South Korea',
+    'en-US': 'South Korea',
+    'de-DE': 'Südkorea',
+    'hi-IN': 'दक्षिण कोरिया',
+    'ko-KR': '대한민국',
+    'ru-RU': 'Республика Корея',
+    'fa-IR': 'کرهٔ جنوبی',
+    'am-ET': 'ደቡብ ኮሪያ',
+  };
+
+  group('Real usage locale flow integration tests', () {
+    testWidgets('Single app session should pass through all locales in sequence',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(const MyApp());
+      await _waitForInit(tester);
+
+      final List<String> failures = <String>[];
+
+      for (final String locale in testLocales) {
+        try {
+          final Finder localeButton =
+              find.widgetWithText(ElevatedButton, locale);
+          if (localeButton.evaluate().isEmpty) {
+            failures.add('[$locale] Locale button not found');
+            continue;
+          }
+
+          await _tapWithVisualDelay(tester, localeButton,
+              delay: localeTapVisualDelay);
+
+          await _waitForLabelToEqual(tester, 'Current Locale', locale);
+
+          _collectMismatch(
+            failures: failures,
+            locale: locale,
+            label: 'Current Locale',
+            actual: _tryGetValueForLabel(tester, 'Current Locale'),
+            expected: locale,
+          );
+
+          _collectMismatch(
+            failures: failures,
+            locale: locale,
+            label: 'DateTime (full)',
+            actual: _tryGetValueForLabel(tester, 'DateTime (full)'),
+            expected: expectedDateTimeValues[locale],
+          );
+
+          _collectMismatch(
+            failures: failures,
+            locale: locale,
+            label: 'First Day Of the Week',
+            actual: _tryGetValueForLabel(tester, 'First Day Of the Week'),
+            expected: expectedFirstDayValues[locale],
+          );
+
+          _collectMismatch(
+            failures: failures,
+            locale: locale,
+            label: 'Clock (12 or 24)',
+            actual: _tryGetValueForLabel(tester, 'Clock (12 or 24)'),
+            expected: expectedClockValues[locale],
+          );
+
+          _collectMismatch(
+            failures: failures,
+            locale: locale,
+            label: 'Number Format',
+            actual: _tryGetValueForLabel(tester, 'Number Format'),
+            expected: expectedNumberFormatValues[locale],
+          );
+
+          // _collectMismatch(
+          //   failures: failures,
+          //   locale: locale,
+          //   label: 'Country',
+          //   actual: _tryGetValueForLabel(tester, 'Country'),
+          //   expected: expectedCountryValues[locale],
+          // );
+        } catch (error) {
+          failures.add('[$locale] Unexpected error: $error');
+        }
+      }
+
+      if (failures.isNotEmpty) {
+        fail('Found ${failures.length} mismatches:\n${failures.join('\n')}');
+      }
+    });
+  });
+}
+
+void _collectMismatch({
+  required List<String> failures,
+  required String locale,
+  required String label,
+  required String? actual,
+  required String? expected,
+}) {
+  if (actual == null) {
+    failures.add('[$locale] $label missing in UI');
+    return;
+  }
+
+  if (expected == null) {
+    failures.add('[$locale] $label expected value is null in test data');
+    return;
+  }
+
+  if (actual != expected) {
+    failures.add(
+        '[$locale] $label mismatch | expected: "$expected" | actual: "$actual"');
+  }
+}
+
+Future<void> _tapWithVisualDelay(WidgetTester tester, Finder button,
+    {Duration delay = const Duration(milliseconds: 700)}) async {
+  await tester.tap(button);
+  await tester.pumpAndSettle();
+  await tester.pump(delay);
+}
+
+Future<void> _waitForInit(WidgetTester tester) async {
+  await _waitUntil(
+      tester, 'iLib Version', (value) => value != 'Unknown iLib');
+}
+
+Future<void> _waitForLabelToEqual(
+    WidgetTester tester, String label, String expected) async {
+  await _waitUntil(tester, label, (value) => value == expected);
+}
+
+Future<void> _waitUntil(
+    WidgetTester tester, String label, bool Function(String) condition,
+    {int maxRetries = 100}) async {
+  for (int i = 0; i < maxRetries; i++) {
+    await tester.pump(const Duration(milliseconds: 100));
+
+    final String? value = _tryGetValueForLabel(tester, label);
+    if (value != null && condition(value)) {
+      await tester.pumpAndSettle();
+      return;
+    }
+  }
+  await tester.pumpAndSettle();
+}
+
+String? _tryGetValueForLabel(WidgetTester tester, String label) {
+  final Finder labelFinder = find.text(label);
+  if (labelFinder.evaluate().isEmpty) return null;
+
+  final Finder rowFinder = find.ancestor(
+    of: labelFinder,
+    matching: find.byType(Row),
+  );
+  if (rowFinder.evaluate().isEmpty) return null;
+
+  final Finder textsInRow = find.descendant(
+    of: rowFinder,
+    matching: find.byType(Text),
+  );
+
+  final List<Text> textWidgets =
+      textsInRow.evaluate().map((Element e) => e.widget as Text).toList();
+  if (textWidgets.length != 2) return null;
+
+  return textWidgets[1].data;
+}
+
+String _getValueForLabel(WidgetTester tester, String label) {
+  final Finder labelFinder = find.text(label);
+  expect(labelFinder, findsOneWidget,
+      reason: 'Should find label "$label" in the widget tree');
+
+  final Finder rowFinder = find.ancestor(
+    of: labelFinder,
+    matching: find.byType(Row),
+  );
+  expect(rowFinder, findsOneWidget,
+      reason: 'Label "$label" should be inside a Row');
+
+  final Finder textsInRow = find.descendant(
+    of: rowFinder,
+    matching: find.byType(Text),
+  );
+
+  final List<Text> textWidgets =
+      textsInRow.evaluate().map((Element e) => e.widget as Text).toList();
+  expect(textWidgets.length, equals(2),
+      reason: 'Row for "$label" should have 2 Text widgets');
+
+  return textWidgets[1].data ?? '';
+}

--- a/example/integration_test/plugin_integration_test.dart
+++ b/example/integration_test/plugin_integration_test.dart
@@ -15,9 +15,9 @@ void main() {
 
   testWidgets('getPlatformVersion test', (WidgetTester tester) async {
     final FlutterILib plugin = FlutterILib.instance;
-    final String version = plugin.getVersion;
+    final String? version = plugin.getVersion;
     // The version string depends on the host platform running the test, so
     // just assert that some non-empty string is returned.
-    expect(version.isNotEmpty, true);
+    expect(version?.isNotEmpty, true);
   });
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -148,9 +148,9 @@ class _MyAppState extends State<MyApp> {
                   for (int i = 0; i < localeList.length; i++)
                     ElevatedButton(
                       child: Text(localeList[i], style: buttonTextStyle),
-                      onPressed: () {
+                      onPressed: () async {
                         curLocale = localeList[i];
-                        _flutterIlibPlugin.loadLocaleData(curLocale);
+                        await _flutterIlibPlugin.loadLocaleData(curLocale);
                         _currentTimeFormat = getDateTimeFormatNow(curLocale);
                         results[0] = getDateTimeFormatFixed(curLocale);
                         results[1] = getFirstDayOfWeek(curLocale);

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -36,6 +36,7 @@ class _MyAppState extends State<MyApp> {
   String _iLibVersion = 'Unknown iLib';
   String _iLibCLDRVersion = 'CLDR';
   String _currentTime = 'Current Time';
+  String _currentTimeFormat = 'Current Time Format';
   static const int _numOfItems = 6;
   List<String> newList = List<String>.generate(_numOfItems, (int index) => '-');
   String curLocale = window.locale.toString().replaceAll('_', '-');
@@ -52,21 +53,22 @@ class _MyAppState extends State<MyApp> {
       if (!mounted) {
         return;
       }
-      if (!_flutterIlibPlugin.isILibReady) {
-        _flutterIlibPlugin.addListener(() => updateState());
-      } else {
+      _flutterIlibPlugin.addListener(() => updateState());
+      if (_flutterIlibPlugin.isILibReady) {
         updateState();
       }
     });
   }
 
   void updateState() {
+    if (!mounted) return;
+
     String iLibVersion;
     String currentTime;
     String iLibCLDRVersion;
 
     try {
-      iLibVersion = _flutterIlibPlugin.getVersion;
+      iLibVersion = _flutterIlibPlugin.getVersion ?? 'Unknown iLib version';
     } on PlatformException {
       iLibVersion = 'Failed to get iLib version.';
     }
@@ -78,22 +80,20 @@ class _MyAppState extends State<MyApp> {
       iLibCLDRVersion = 'Failed to get iLib CLDR version.';
     }
 
-    try {
-      currentTime = getDateTimeFormatNow('en-US');
-    } on PlatformException {
-      currentTime = 'Failed to get iLib DatFmt.';
-    }
+    final now = DateTime.now();
+    currentTime = '${now.year}-${now.month.toString().padLeft(2, '0')}-${now.day.toString().padLeft(2, '0')} ${now.hour.toString().padLeft(2, '0')}:${now.minute.toString().padLeft(2, '0')}';
 
-    results[0] = getDateTimeFormat(curLocale);
+    results[0] = getDateTimeFormatFixed(curLocale);
     results[1] = getFirstDayOfWeek(curLocale);
     results[2] = getClock(curLocale);
-    //results[3] = getNumFmt(curLocale);
-    //results[4] = getCountry(curLocale);
+    results[3] = getNumFmt(curLocale);
+    // results[4] = getCountry(curLocale);
 
     setState(() {
       _iLibVersion = iLibVersion;
       _iLibCLDRVersion = iLibCLDRVersion;
       _currentTime = currentTime;
+      _currentTimeFormat = getDateTimeFormatNow(curLocale);
       newList = results;
     });
   }
@@ -135,7 +135,7 @@ class _MyAppState extends State<MyApp> {
               _customTextBox('DateTime (full)', newList[0]),
               _customTextBox('First Day Of the Week', newList[1]),
               _customTextBox('Clock (12 or 24)', newList[2]),
-              //_customTextBox('Number Format', newList[3]),
+              _customTextBox('Number Format', newList[3]),
               //_customTextBox('Country', newList[4]),
               const SizedBox(
                 height: 30,
@@ -151,10 +151,11 @@ class _MyAppState extends State<MyApp> {
                       onPressed: () {
                         curLocale = localeList[i];
                         _flutterIlibPlugin.loadLocaleData(curLocale);
-                        results[0] = getDateTimeFormat(curLocale);
+                        _currentTimeFormat = getDateTimeFormatNow(curLocale);
+                        results[0] = getDateTimeFormatFixed(curLocale);
                         results[1] = getFirstDayOfWeek(curLocale);
                         results[2] = getClock(curLocale);
-                        //results[3] = getNumFmt(curLocale);
+                        results[3] = getNumFmt(curLocale);
                         //results[4] = getCountry(curLocale);
                         setState(() {
                           newList = results;
@@ -169,6 +170,7 @@ class _MyAppState extends State<MyApp> {
               _customTextBox('iLib Version', _iLibVersion, main: false),
               _customTextBox('CLDR Version', _iLibCLDRVersion, main: false),
               _customTextBox('Current Time', _currentTime),
+              _customTextBox('Current DateTime (full)', _currentTimeFormat),
             ],
           ),
         ),
@@ -207,11 +209,11 @@ class _MyAppState extends State<MyApp> {
     return fmt.format(dateOptions);
   }
 
-  String getDateTimeFormat(String curlo) {
+  String getDateTimeFormatFixed(String lo) {
     final ILibDateOptions dateOptions =
-        ILibDateOptions(dateTime: DateTime.now());
+        ILibDateOptions(dateTime: DateTime(2026, 5, 23, 16, 30, 0));
     final ILibDateFmtOptions fmtOptions = ILibDateFmtOptions(
-        locale: curlo,
+        locale: lo,
         length: 'full',
         type: 'datetime',
         useNative: false,
@@ -241,17 +243,14 @@ class _MyAppState extends State<MyApp> {
     final int clock = ILibDateFmt(fmtOptions).getClock();
     return '$clock';
   }
-  /*
+
   String getNumFmt(String curlo) {
     final ILibNumFmt fmt = ILibNumFmt(ILibNumFmtOptions(locale: curlo));
     return fmt.format(-111123456.785);
-  }*/
+  }
 
-  /*String getCountry(String curlo) {
-    final ILibCountry ctry = ILibCountry(locale: curlo);
-    return ctry.getName('KR');
-  }*/
   // String getCountry(String curlo) {
-  //   return 'SA';
+  //   final ILibCountry ctry = ILibCountry(locale: curlo);
+  //   return ctry.getName('KR');
   // }
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -109,26 +109,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -165,10 +165,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
@@ -258,18 +258,18 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.7"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:
@@ -287,5 +287,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=3.7.0-0 <4.0.0"
+  dart: ">=3.8.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/execute_unit_test.sh
+++ b/execute_unit_test.sh
@@ -11,11 +11,13 @@ FAILED_TESTS=()
 # Ignore info-level logs during test
 FLUTTER_OPTIONS="--dart-define=TEST_MODE=true"
 
-for test_file in $(find test/ \( -path 'test/durfmt' -o -path 'test/country' -o -path 'test/numfmt' -o -path 'test/scriptinfo' \) -prune -o -path 'test/basic/flutter_ilib_numfmt_test.dart' -prune -o -path 'test/basic/flutter_ilib_datefmt_test.dart' -prune -o -name '*_test.dart' -print); do
+for test_file in $(find test/ \( -path 'test/durfmt' -o -path 'test/country' -o -path 'test/scriptinfo' \) -prune -o -name '*_test.dart' -print
+); do
   if ! flutter test "$test_file" $FLUTTER_OPTIONS; then
     FAILED_TESTS+=("$test_file")
   fi
 done
+
 
 if [[ ${#FAILED_TESTS[@]} -gt 0 ]]; then
   echo ""

--- a/execute_unit_test.sh
+++ b/execute_unit_test.sh
@@ -1,30 +1,137 @@
 #!/usr/bin/env bash
+#
+# execute_unit_test.sh
+#
+# Run tests for flutter_ilib.
+# This script must be executed from the project root directory.
+#
+# Usage:
+#   ./execute_unit_test.sh          # Run all tests (default)
+#   ./execute_unit_test.sh unit      # Run library API tests only
+#   ./execute_unit_test.sh integration      # Run example app tests only
+#
+# Test structure:
+#   - test/ (excluding test/integration/) : Unit tests (datefmt, numfmt, durfmt, etc.)
+#   - test/integration/                   : API-level integration tests
+#   - example/integration_test/           : Widget-based integration tests (requires Linux device)
+#
+
 set -e
+
+PROJECT_ROOT="${PWD}"
 
 test_log() {
   echo "[flutter_ilib] $1"
 }
 
-test_log "Execute unit tests..."
-echo ""
-FAILED_TESTS=()
-# Ignore info-level logs during test
+run_linux_flutter_test() {
+  local test_file="$1"
+  shift
+
+  if [[ -z "${DISPLAY:-}" ]] && command -v xvfb-run > /dev/null; then
+    xvfb-run -a flutter test "$test_file" "$@"
+    return
+  fi
+
+  flutter test "$test_file" "$@"
+}
+
+# --- Common setup ---
+FAILED_UNIT_TESTS=()
+FAILED_INTEGRATION_TESTS=()
+RUN_UNIT_TESTS=false
+RUN_INTEGRATION_TESTS=false
+# Suppress info-level logs during test execution
 FLUTTER_OPTIONS="--dart-define=TEST_MODE=true"
 
-for test_file in $(find test/ \( -path 'test/durfmt' -o -path 'test/country' -o -path 'test/scriptinfo' \) -prune -o -name '*_test.dart' -print
-); do
-  if ! flutter test "$test_file" $FLUTTER_OPTIONS; then
-    FAILED_TESTS+=("$test_file")
-  fi
-done
+# --- Test functions ---
 
-
-if [[ ${#FAILED_TESTS[@]} -gt 0 ]]; then
+run_unit_tests() {
+  RUN_UNIT_TESTS=true
+  test_log "Execute unit tests (test/)..."
   echo ""
-  test_log "** Failed tests **"
-  for failed in "${FAILED_TESTS[@]}"; do
-    echo " ❌ $failed"
+  for test_file in $(find test/ \( -path 'test/durfmt' -o -path 'test/country' -o -path 'test/scriptinfo' -o -path 'test/integration' \) -prune -o -name '*_test.dart' -print
+  ); do
+    if ! flutter test "$test_file" $FLUTTER_OPTIONS; then
+      FAILED_UNIT_TESTS+=("$test_file")
+    fi
   done
+}
+
+run_integration_tests() {
+  RUN_INTEGRATION_TESTS=true
+  # API-level integration tests
+  test_log "Execute API-level integration tests (test/integration/)..."
+  echo ""
+  for test_file in $(find test/integration/ -name '*_test.dart'); do
+    if ! flutter test "$test_file" $FLUTTER_OPTIONS; then
+      FAILED_INTEGRATION_TESTS+=("$test_file")
+    fi
+  done
+
+  # Widget-based integration tests (must run from example/ directory)
+  test_log "Execute widget-based integration tests (example/integration_test/)..."
+  echo ""
+  pushd example > /dev/null
+  for test_file in $(find integration_test/ -name '*_test.dart'); do
+    if ! run_linux_flutter_test "$test_file" $FLUTTER_OPTIONS -d linux; then
+      FAILED_INTEGRATION_TESTS+=("example/$test_file")
+    fi
+  done
+  popd > /dev/null
+}
+
+# --- Option handling ---
+
+MODE="${1:-all}"
+
+case "$MODE" in
+  unit)
+    run_unit_tests
+    ;;
+  integration)
+    run_integration_tests
+    ;;
+  all)
+    run_unit_tests
+    run_integration_tests
+    ;;
+  *)
+    echo "Usage: $0 [unit|integration|all]"
+    exit 1
+    ;;
+esac
+
+echo ""
+echo "-------------------------------------"
+# --- Report results ---
+if [[ "$RUN_UNIT_TESTS" == true ]]; then
+  echo ""
+  test_log "[unit] result"
+  if [[ ${#FAILED_UNIT_TESTS[@]} -gt 0 ]]; then
+    echo " ❌ failed"
+    for failed in "${FAILED_UNIT_TESTS[@]}"; do
+      echo "   - $failed"
+    done
+  else
+    echo " ✅ passed"
+  fi
+fi
+
+if [[ "$RUN_INTEGRATION_TESTS" == true ]]; then
+  echo ""
+  test_log "[integration] result"
+  if [[ ${#FAILED_INTEGRATION_TESTS[@]} -gt 0 ]]; then
+    echo " ❌ failed"
+    for failed in "${FAILED_INTEGRATION_TESTS[@]}"; do
+      echo "   - $failed"
+    done
+  else
+    echo " ✅ passed"
+  fi
+fi
+
+if [[ ${#FAILED_UNIT_TESTS[@]} -gt 0 || ${#FAILED_INTEGRATION_TESTS[@]} -gt 0 ]]; then
   exit 1
 else
   echo ""

--- a/lib/calendar/ilib_astro.dart
+++ b/lib/calendar/ilib_astro.dart
@@ -3,7 +3,6 @@ import 'dart:math';
 import 'package:flutter/foundation.dart' show visibleForTesting;
 
 import '../ilib_init.dart';
-import '../internal/ilib_utils.dart';
 import 'greg_rata_die.dart';
 
 class ILibAstro {
@@ -12,14 +11,19 @@ class ILibAstro {
   static Map<String, dynamic>? _data;
 
   static Map<String, dynamic> _getData() {
-    if (_data != null) {
+    // astro is locale-independent (root.json only). Read it from the root data
+    // directly so it does not depend on currentLocale being valid/loaded, and
+    // never cache an empty map (so a too-early call can recover later).
+    if (_data != null && _data!.isNotEmpty) {
       return _data!;
     }
-    final Map<String, dynamic>? localeData =
-        ILibLoader.instance.getLocaleData(currentLocale);
-    _data = (localeData?['ilib.data.astro'] as Map<String, dynamic>?) ??
-        <String, dynamic>{};
-    return _data!;
+    final Map<String, dynamic>? rootData = ILibLoader.instance.getRootData();
+    final Map<String, dynamic>? astro =
+        rootData?['ilib.data.astro'] as Map<String, dynamic>?;
+    if (astro != null && astro.isNotEmpty) {
+      _data = astro;
+    }
+    return astro ?? const <String, dynamic>{};
   }
 
   static double _dtr(double d) => d * pi / 180.0;

--- a/lib/flutter_ilib.dart
+++ b/lib/flutter_ilib.dart
@@ -14,6 +14,7 @@ export 'ilib_datefmt.dart';
 export 'ilib_init.dart';
 export 'ilib_locale.dart';
 export 'ilib_localeinfo.dart';
+export 'ilib_numfmt.dart';
 export 'ilib_timezone.dart';
 
 class FlutterILib extends ChangeNotifier {

--- a/lib/ilib_init.dart
+++ b/lib/ilib_init.dart
@@ -29,9 +29,19 @@ class ILibLoader extends ChangeNotifier {
 
   final Set<String> _availableAssets = <String>{};
 
+  static const String _rootPath =
+      'packages/flutter_ilib/assets/locale/root.json';
+
   Map<String, dynamic>? getLocaleData(String locale) {
     return _localeDataMap[locale] ?? _mergeFromCache(locale);
   }
+
+  /// Locale-independent data from root.json (e.g. `ilib.data.astro`).
+  ///
+  /// root.json is always loaded first by [loadJSON], so this is available
+  /// regardless of which locales have been loaded — unlike [getLocaleData],
+  /// which depends on a (valid, loaded) locale.
+  Map<String, dynamic>? getRootData() => _fileDataCache[_rootPath];
 
   Map<String, dynamic>? _mergeFromCache(String locale) {
     final List<String> paths = getJSONDataPaths(locale);
@@ -130,9 +140,10 @@ class ILibLoader extends ChangeNotifier {
     await _loadAssetManifest();
 
     // Always load root.json first as it contains locale-independent data (e.g. astro)
-    await _loadFile('packages/flutter_ilib/assets/locale/root.json');
+    await _loadFile(_rootPath);
 
-    String curlocale = getLocale();
+    // normalizeLocale maps C/POSIX/und/empty to en-US.
+    String curlocale = normalizeLocale(getLocale());
     if (!isValidLocale(curlocale)) {
       logger.warn('Invalid locale: $curlocale, falling back to en-US');
       curlocale = 'en-US';
@@ -161,7 +172,8 @@ class ILibLoader extends ChangeNotifier {
       return;
     }
 
-    locale ??= getLocale();
+    // normalizeLocale maps C/POSIX/und/empty to en-US instead of rejecting.
+    locale = normalizeLocale(locale ?? getLocale());
     if (!isValidLocale(locale)) {
       return;
     }

--- a/lib/ilib_init.dart
+++ b/lib/ilib_init.dart
@@ -132,12 +132,12 @@ class ILibLoader extends ChangeNotifier {
     // Always load root.json first as it contains locale-independent data (e.g. astro)
     await _loadFile('packages/flutter_ilib/assets/locale/root.json');
 
-    final String curlocale = getLocale();
-    if (isValidLocale(curlocale)) {
-      await _loadLocaleData(curlocale);
-    } else {
-      logger.warn('Invalid locale: $curlocale, no locale-specific data loaded');
+    String curlocale = getLocale();
+    if (!isValidLocale(curlocale)) {
+      logger.warn('Invalid locale: $curlocale, falling back to en-US');
+      curlocale = 'en-US';
     }
+    await _loadLocaleData(curlocale);
 
     initILib();
     logger.info('Notifying listeners after JSON loading');

--- a/lib/ilib_numfmt.dart
+++ b/lib/ilib_numfmt.dart
@@ -1,194 +1,493 @@
 import 'ilib_init.dart';
+import 'ilib_localeinfo.dart';
+import 'internal/ilib_utils.dart' as ilib_utils;
+import 'internal/math_utils.dart' as math_utils;
+
+/// Padding string of zeros for fraction formatting.
+const String _zeros = '00000000000000000000000000000000000000000000000000000000000000000000';
 
 class ILibNumFmt {
   /// [options] Set the Options for formatting
   ILibNumFmt(ILibNumFmtOptions options) {
-    locale = options.locale;
-    type = options.type;
-    currency = options.currency;
-    maxFractionDigits = options.maxFractionDigits;
-    minFractionDigits = options.minFractionDigits;
-    significantDigits = options.significantDigits;
-    roundingMode = options.roundingMode;
-    style = options.style;
-    useNative = options.useNative;
-  }
+    _locale = options.locale ?? ilib_utils.getLocale();
+    _type = _validType(options.type);
 
-  String? locale;
-  String? type;
-  String? currency;
-  int? maxFractionDigits;
-  int? minFractionDigits;
-  int? significantDigits;
-  String? style;
-  String? roundingMode;
-  bool? useNative;
+    final ILibLocaleInfo locInfo = ILibLocaleInfo(_locale);
 
-  /// A string representation of parameters to call functions of iLib library properly
-  String toJsonString() {
-    String result = '';
-    String completeOption = '';
-
-    final Map<String, String> paramInfo = <String, String>{
-      'locale': '$locale',
-      'type': '$type',
-      'currency': '$currency',
-      'maxFractionDigits': '$maxFractionDigits',
-      'minFractionDigits': '$minFractionDigits',
-      'significantDigits': '$significantDigits',
-      'style': '$style',
-      'roundingMode': '$roundingMode'
-    };
-    paramInfo.forEach((String key, String value) {
-      if (value != 'null') {
-        result += '$key:"$value",';
-      }
-    });
-
-    if (useNative != null) {
-      result += 'useNative:$useNative,';
+    // Resolve style
+    if (_type == 'currency') {
+      _style = (options.style == 'common' || options.style == 'iso') ? options.style! : 'common';
+    } else {
+      _style = options.style ?? 'standard';
     }
 
-    result =
-        result.isNotEmpty ? result.substring(0, result.length - 1) : result;
-    completeOption = '{$result}';
+    // Resolve fraction digits from options
+    _maxFractionDigits = options.maxFractionDigits;
+    _minFractionDigits = options.minFractionDigits;
+    _significantDigits = options.significantDigits;
 
-    return completeOption;
+    // Enforce limits on significantDigits
+    if (_significantDigits != null) {
+      if (_significantDigits! < 1) {
+        _significantDigits = 1;
+      }
+      if (_significantDigits! > 20) {
+        _significantDigits = 20;
+      }
+    }
+    // Enforce limits on minFractionDigits
+    if (_minFractionDigits != null) {
+      if (_minFractionDigits! < 0) {
+        _minFractionDigits = 0;
+      }
+      if (_minFractionDigits! > 20) {
+        _minFractionDigits = 20;
+      }
+    }
+
+    // Currency setup
+    if (_type == 'currency') {
+      _initCurrency(options.currency, locInfo);
+    }
+
+    // Percentage templates
+    if (_type == 'percentage') {
+      _template = locInfo.getPercentageFormat();
+      _templateNegative = locInfo.getNegativePercentageFormat();
+    }
+
+    // Number negative template
+    if (_type == 'number') {
+      _templateNegative = locInfo.getNegativeNumberFormat();
+    }
+
+    // Resolve rounding mode
+    _roundingMode = options.roundingMode ?? _currencyRoundingMode ?? locInfo.getRoundingMode();
+    _round = math_utils.getRoundingFunction(_roundingMode);
+
+    // Resolve useNative
+    _resolveUseNative(options.useNative, locInfo);
+
+    // Init separators, grouping, digits
+    _init(locInfo);
   }
 
-  /// Format a number according to the settings of this number formatter instance
+  late String _locale;
+  late String _type;
+  late String _style;
+  late String _roundingMode;
+  late double Function(double) _round;
+  int? _maxFractionDigits;
+  int? _minFractionDigits;
+  int? _significantDigits;
+  late bool _useNative;
+  late String _decimalSeparator;
+  late String _groupingSeparator;
+  late int _prigroupSize;
+  late int _secgroupSize;
+  late String _exponentSymbol;
+  List<String>? _digits;
+
+  // Currency
+  String? _currencyCode;
+  String? _currencySign;
+  String? _currencyRoundingMode;
+
+  // Templates
+  String _template = '{n}';
+  String _templateNegative = '-{n}';
+
+  static String _validType(String? type) {
+    if (type == 'number' || type == 'currency' || type == 'percentage') {
+      return type!;
+    }
+    return 'number';
+  }
+
+  void _initCurrency(String? currency, ILibLocaleInfo locInfo) {
+    _currencyCode = currency;
+
+    final Map<String, dynamic>? localeData = ILibLoader.instance.getLocaleData(_locale);
+    final Map<String, dynamic>? allCurrencies =
+        localeData?['ilib.data.currency'] as Map<String, dynamic>?;
+    final Map<String, dynamic>? currInfo = (allCurrencies != null && _currencyCode != null)
+        ? allCurrencies[_currencyCode] as Map<String, dynamic>?
+        : null;
+
+    int currencyDecimals = 2;
+    if (currInfo != null) {
+      currencyDecimals = (currInfo['decimals'] as num?)?.toInt() ?? 2;
+      _currencySign = currInfo['sign'] as String? ?? _currencyCode;
+    } else {
+      _currencySign = _currencyCode;
+    }
+
+    // Set fraction digits to currency decimals if user didn't override
+    if (_maxFractionDigits == null && _minFractionDigits == null) {
+      _maxFractionDigits = currencyDecimals;
+      _minFractionDigits = currencyDecimals;
+    }
+
+    // Currency rounding mode
+    _currencyRoundingMode = currInfo?['roundingMode'] as String?;
+
+    // Currency format templates
+    final CurrencyFormats formats = locInfo.getCurrencyFormats();
+    if (_style == 'iso') {
+      final String isoFmt = formats.iso ?? '';
+      final String isoNeg = formats.isoNegative ?? '';
+      _template = isoFmt.isNotEmpty ? isoFmt : (formats.common ?? '{s} {n}');
+      _templateNegative = isoNeg.isNotEmpty ? isoNeg : (formats.commonNegative ?? '-{s} {n}');
+      _currencySign = _currencyCode;
+    } else {
+      _template = (formats.common?.isNotEmpty ?? false) ? formats.common! : '{s} {n}';
+      _templateNegative =
+          (formats.commonNegative?.isNotEmpty ?? false) ? formats.commonNegative! : '-{s} {n}';
+    }
+  }
+
+  void _resolveUseNative(bool? optionUseNative, ILibLocaleInfo locInfo) {
+    if (optionUseNative != null) {
+      _useNative = optionUseNative;
+    } else {
+      final String digitsStyle = locInfo.getDigitsStyle();
+      if (digitsStyle == 'native') {
+        _useNative = true;
+      } else if (digitsStyle == 'optional' && _style == 'native') {
+        _useNative = true;
+      } else {
+        _useNative = false;
+      }
+    }
+  }
+
+  void _init(ILibLocaleInfo locInfo) {
+    // Enforce min <= max
+    if (_maxFractionDigits != null &&
+        _minFractionDigits != null &&
+        _maxFractionDigits! >= 0 &&
+        _maxFractionDigits! < _minFractionDigits!) {
+      _minFractionDigits = _maxFractionDigits;
+    }
+
+    // Grouping
+    if (_style == 'nogrouping') {
+      _prigroupSize = 0;
+      _secgroupSize = 0;
+      _groupingSeparator = '';
+    } else {
+      _prigroupSize = locInfo.getPrimaryGroupingDigits();
+      _secgroupSize = locInfo.getSecondaryGroupingDigits();
+      _groupingSeparator =
+          _useNative ? locInfo.getNativeGroupingSeparator() : locInfo.getGroupingSeparator();
+    }
+
+    // Decimal separator
+    _decimalSeparator =
+        _useNative ? locInfo.getNativeDecimalSeparator() : locInfo.getDecimalSeparator();
+
+    // Native digits
+    if (_useNative) {
+      final String? nd = locInfo.getNativeDigits() ?? locInfo.getDigits();
+      if (nd != null && nd.isNotEmpty) {
+        _digits = nd.split('');
+      }
+    }
+
+    // Exponential symbol
+    _exponentSymbol = _useNative ? locInfo.getNativeExponential() : locInfo.getExponential();
+  }
+
+  String _mapDigits(String str) {
+    if (_digits == null) {
+      return str;
+    }
+    final StringBuffer result = StringBuffer();
+    for (int i = 0; i < str.length; i++) {
+      final int code = str.codeUnitAt(i);
+      if (code >= 48 && code <= 57) {
+        result.write(_digits![code - 48]);
+      } else {
+        result.write(str[i]);
+      }
+    }
+    return result.toString();
+  }
+
+  /// Apply constraints (significantDigits, maxFractionDigits, rounding) to a number.
+  double _constrain(double num) {
+    double result = num;
+    final String parts0 = num.abs().toString().split('.')[0];
+
+    // Apply significantDigits if it would result in fewer digits than maxFractionDigits
+    if (_significantDigits != null &&
+        _significantDigits! > 0 &&
+        (_maxFractionDigits == null ||
+            _maxFractionDigits! < 0 ||
+            parts0.length + _maxFractionDigits! > _significantDigits!)) {
+      result = math_utils.significant(result, _significantDigits!, _round);
+    }
+
+    // Apply maxFractionDigits
+    if (_maxFractionDigits != null && _maxFractionDigits! > -1) {
+      result =
+          math_utils.shiftDecimal(_round(math_utils.shiftDecimal(result, _maxFractionDigits!)), -_maxFractionDigits!);
+    }
+
+    return result;
+  }
+
+  /// Format the number using standard (non-scientific) notation.
+  String _formatStandard(double num) {
+    final double absConstrained = _constrain(num).abs();
+
+    final List<String> parts = absConstrained.toString().split('.');
+    final String integral = parts[0];
+    String? fraction = parts.length > 1 ? parts[1] : null;
+
+    // Remove trailing zeros artifact from double conversion
+    // but only if no minFractionDigits is set
+    if (fraction == '0' &&
+        (_minFractionDigits == null || _minFractionDigits! <= 0) &&
+        (_maxFractionDigits == null || _maxFractionDigits! < 0)) {
+      fraction = null;
+    } else if (fraction == '0' && _maxFractionDigits != null && _maxFractionDigits == 0) {
+      fraction = null;
+    }
+
+    // Pad fraction to minFractionDigits
+    if (_minFractionDigits != null && _minFractionDigits! > 0) {
+      final String frac = fraction ?? '';
+      if (frac.length < _minFractionDigits!) {
+        fraction = frac + _zeros.substring(0, _minFractionDigits! - frac.length);
+      }
+    }
+
+    // Apply grouping
+    String formatted;
+    if (_secgroupSize > 0) {
+      formatted = _applySecondaryGrouping(integral);
+    } else if (_prigroupSize > 0) {
+      formatted = _applyPrimaryGrouping(integral);
+    } else {
+      formatted = integral;
+    }
+
+    // Add fractional part
+    if (fraction != null &&
+        fraction.isNotEmpty &&
+        ((_maxFractionDigits == null && _significantDigits == null) ||
+            (_maxFractionDigits != null && _maxFractionDigits! > 0) ||
+            (_significantDigits != null && _significantDigits! > 0))) {
+      formatted += _decimalSeparator + fraction;
+    }
+
+    // Native digit substitution
+    if (_digits != null) {
+      formatted = _mapDigits(formatted);
+    }
+
+    return formatted;
+  }
+
+  /// Apply primary-only grouping (e.g., Western style: 1,234,567).
+  String _applyPrimaryGrouping(String integral) {
+    if (integral.length <= _prigroupSize) {
+      return integral;
+    }
+    final StringBuffer result = StringBuffer();
+    int cycle = (integral.length - 1) % _prigroupSize;
+    for (int i = 0; i < integral.length - 1; i++) {
+      result.write(integral[i]);
+      if (cycle == 0) {
+        result.write(_groupingSeparator);
+      }
+      cycle = (cycle - 1) % _prigroupSize;
+      if (cycle < 0) {
+        cycle += _prigroupSize;
+      }
+    }
+    result.write(integral[integral.length - 1]);
+    return result.toString();
+  }
+
+  /// Apply secondary grouping (e.g., Indian style: 12,34,56,789).
+  String _applySecondaryGrouping(String integral) {
+    if (integral.length <= _prigroupSize) {
+      return integral;
+    }
+    // First group from right: prigroupSize
+    final int size3 = integral.length - _prigroupSize;
+    String result =
+        '${integral.substring(0, size3)}$_groupingSeparator${integral.substring(size3)}';
+
+    // Apply secondary grouping to the left part
+    String numSec = result.substring(0, result.indexOf(_groupingSeparator));
+    while (numSec.length > _secgroupSize) {
+      final int secSize3 = numSec.length - _secgroupSize;
+      result = '${result.substring(0, secSize3)}$_groupingSeparator${result.substring(secSize3)}';
+      numSec = result.substring(0, result.indexOf(_groupingSeparator));
+    }
+
+    return result;
+  }
+
+  /// Format the number using scientific notation.
+  String _formatScientific(double num) {
+    final double n = num.abs();
+    final String str = n.toStringAsExponential();
+    final List<String> expParts = str.split('e');
+    final String exponent = expParts[1];
+
+    // Only re-parse as double when digit constraints need rounding.
+    // Avoid unnecessary string→double→string round-trip which can lose
+    // the last significant digit due to IEEE 754 precision limits.
+    final bool needsConstraints =
+        (_maxFractionDigits != null && _maxFractionDigits! > 0) ||
+        (_significantDigits != null && _significantDigits! > 0);
+
+    String significandStr = expParts[0];
+
+    if (needsConstraints) {
+      double significantPart = double.parse(significandStr);
+      int maxDigits = (_maxFractionDigits ?? 25) + 1;
+      if (_significantDigits != null && _significantDigits! > 0) {
+        if (maxDigits > _significantDigits!) {
+          maxDigits = _significantDigits!;
+        }
+      }
+      significantPart = math_utils.significant(significantPart, maxDigits, _round);
+      significandStr = significantPart.toString();
+    }
+
+    final List<String> numParts = significandStr.split('.');
+    final String integral = numParts[0];
+    String? fraction = numParts.length > 1 ? numParts[1] : null;
+
+    // Truncate fraction to maxFractionDigits
+    final int maxFrac = _maxFractionDigits ?? -1;
+    if (maxFrac >= 0 && fraction != null && fraction.length > maxFrac) {
+      fraction = fraction.substring(0, maxFrac);
+    }
+
+    // Pad fraction to minFractionDigits
+    final int minFrac = _minFractionDigits ?? -1;
+    if (minFrac > 0) {
+      final String frac = fraction ?? '';
+      if (frac.length < minFrac) {
+        fraction = frac + _zeros.substring(0, minFrac - frac.length);
+      }
+    }
+
+    String formatted = integral;
+    if (fraction != null && fraction.isNotEmpty && fraction != '0') {
+      formatted += _decimalSeparator + fraction;
+    } else if (minFrac > 0) {
+      formatted += _decimalSeparator + (fraction ?? _zeros.substring(0, minFrac));
+    }
+    formatted += _exponentSymbol + exponent;
+
+    if (_digits != null) {
+      formatted = _mapDigits(formatted);
+    }
+
+    return formatted;
+  }
+
+  /// Format a number according to the settings of this number formatter instance.
   String format(dynamic number) {
-    String result = '';
-    if (number != null) {
-      if (number is! num && number is! String) {
-        throw ArgumentError(
-            'Invalid argument type. Expected num or String, got ${number.runtimeType}');
-      }
-      if (number is num && (number.isNaN || number.isInfinite)) {
-        return number.toString();
-      }
-
-      final String formatOptions = toJsonString();
-      final String numStr = number is String ? number : number.toString();
-      result = ILibJS.instance
-          .evaluate('new NumFmt($formatOptions).format($numStr).toString()')
-          .stringResult;
+    if (number == null) {
+      return '';
     }
-    return result;
+    if (number is! num && number is! String) {
+      throw ArgumentError(
+          'Invalid argument type. Expected num or String, got ${number.runtimeType}');
+    }
+    if (number is num && (number.isNaN || number.isInfinite)) {
+      return number.toString();
+    }
+
+    final double n = number is String ? double.parse(number) : (number as num).toDouble();
+
+    if (_type == 'number') {
+      final String formatted = (_style == 'scientific') ? _formatScientific(n) : _formatStandard(n);
+      if (n < 0) {
+        return _templateNegative.replaceAll('{n}', formatted);
+      }
+      return formatted;
+    } else {
+      // currency or percentage
+      final String formatted = _formatStandard(n);
+      final String template = (n < 0) ? _templateNegative : _template;
+      String result = template.replaceAll('{n}', formatted);
+      if (_type == 'currency' && _currencySign != null) {
+        result = result.replaceAll('{s}', _currencySign!);
+      }
+      return result;
+    }
   }
 
-  /// Apply the constraints used in the current formatter to the given number
+  /// Apply the constraints used in the current formatter to the given number.
   String constrain(int number) {
-    String result = '';
-    final String formatOptions = toJsonString();
-    result = ILibJS.instance
-        .evaluate('new NumFmt($formatOptions).constrain($number).toString()')
-        .stringResult;
-
-    return result;
+    return _constrain(number.toDouble()).toString();
   }
 
-  /// Return the locale that was used to construct this number formatter object.<br>
-  /// If the locale was not given as parameter to the constructor, this method returns the default
-  /// locale of the system.
+  /// Return the locale that was used to construct this number formatter object.
   String getLocale() {
-    String result = '';
-    final String formatOptions = toJsonString();
-    final String jscode1 = 'new NumFmt($formatOptions).getLocale().toString()';
-    result = ILibJS.instance.evaluate(jscode1).stringResult;
-    return result;
+    return _locale;
   }
 
   /// Return the type of formatter. Valid values are "number", "currency", and "percentage".
   String getType() {
-    String result = '';
-    final String formatOptions = toJsonString();
-    final String jscode1 = 'new NumFmt($formatOptions).getType()';
-    result = ILibJS.instance.evaluate(jscode1).stringResult;
-    return result;
+    return _type;
   }
 
   /// Returns true if this formatter groups together digits in the integral
-  /// portion of a number, based on the options set up in the constructor
+  /// portion of a number.
   bool isGroupingUsed() {
-    String result = '';
-    final String formatOptions = toJsonString();
-    final String jscode1 = 'new NumFmt($formatOptions).isGroupingUsed()';
-    result = ILibJS.instance.evaluate(jscode1).stringResult;
-    return result.toLowerCase() == 'true';
+    return _prigroupSize > 0 && _style != 'nogrouping';
   }
 
-  /// Returns the maximum fraction digits set up in the constructor
+  /// Returns the maximum fraction digits set up in the constructor.
+  /// -1 means unlimited.
   int getMaxFractionDigits() {
-    String result = '';
-    final String formatOptions = toJsonString();
-    final String jscode1 = 'new NumFmt($formatOptions).getMaxFractionDigits()';
-    result = ILibJS.instance.evaluate(jscode1).stringResult;
-    return int.parse(result);
+    return _maxFractionDigits ?? -1;
   }
 
-  /// Returns the minimum fraction digits set up in the constructor
+  /// Returns the minimum fraction digits set up in the constructor.
+  /// -1 means not set.
   int getMinFractionDigits() {
-    String result = '';
-    final String formatOptions = toJsonString();
-    final String jscode1 = 'new NumFmt($formatOptions).getMinFractionDigits()';
-    result = ILibJS.instance.evaluate(jscode1).stringResult;
-    return int.parse(result);
+    return _minFractionDigits ?? -1;
   }
 
-  /// Returns the significant digits set up in the constructor
+  /// Returns the significant digits set up in the constructor.
+  /// -1 means not set.
   int getSignificantDigits() {
-    String result = '';
-    final String formatOptions = toJsonString();
-    final String jscode1 = 'new NumFmt($formatOptions).getSignificantDigits()';
-    result = ILibJS.instance.evaluate(jscode1).stringResult;
-    return int.parse(result);
+    return _significantDigits ?? -1;
   }
 
-  /// Returns the ISO 4217 code for the currency that this formatter formats<br>
-  /// If this formatter's type is not "currency", then this method will return null.
-  int? getCurrency() {
-    String result = '';
-    final String formatOptions = toJsonString();
-    final String jscode1 = 'new NumFmt($formatOptions).getCurrency()';
-    result = ILibJS.instance.evaluate(jscode1).stringResult;
-
-    if (result == null || result.isEmpty || result == 'null') {
+  /// Returns the ISO 4217 code for the currency that this formatter formats.
+  /// Returns null if type is not "currency".
+  String? getCurrency() {
+    if (_type != 'currency') {
       return null;
     }
-
-    return int.parse(result);
+    return _currencyCode;
   }
 
-  /// Returns the rounding mode set up in the constructor.<br>
-  /// The rounding mode controls how numbers are rounded when the integral or fraction digits
-  /// of a number are limited.
+  /// Returns the rounding mode set up in the constructor.
   String getRoundingMode() {
-    String result = '';
-    final String formatOptions = toJsonString();
-    final String jscode1 = 'new NumFmt($formatOptions).getRoundingMode()';
-    result = ILibJS.instance.evaluate(jscode1).stringResult;
-    return result;
+    return _roundingMode;
   }
 
-  /// Return the style that was used to construct this number formatter object.<br>
-  /// Valid values are for "currency": "common" (symbol) or "iso" (ISO code).<br>
-  /// for "number": "standard", "scientific", "native", or "nogrouping".<br>
+  /// Return the style that was used to construct this number formatter object.
   String getStyle() {
-    String result = '';
-    final String formatOptions = toJsonString();
-    final String jscode1 = 'new NumFmt($formatOptions).getStyle()';
-    result = ILibJS.instance.evaluate(jscode1).stringResult;
-    return result;
+    return _style;
   }
 
-  /// Return true if this formatter uses native digits to format the number
+  /// Return true if this formatter uses native digits to format the number.
   bool getUseNative() {
-    String result = '';
-    final String formatOptions = toJsonString();
-    final String jscode1 = 'new NumFmt($formatOptions).getUseNative()';
-    result = ILibJS.instance.evaluate(jscode1).stringResult;
-    return result.toLowerCase() == 'true';
+    return _useNative;
   }
 }
 

--- a/lib/internal/ilib_utils.dart
+++ b/lib/internal/ilib_utils.dart
@@ -2,15 +2,33 @@ import 'dart:ui';
 
 import '../ilib_locale.dart';
 
-String currentLocale =
-    PlatformDispatcher.instance.locale.toString().replaceAll('_', '-');
+String _currentLocale =
+    normalizeLocale(PlatformDispatcher.instance.locale.toString());
 
-String getLocale() {
-  return currentLocale;
-}
+/// The active locale, always normalized — it can never be observed as
+/// `C`/`POSIX`/`und`/empty (those collapse to `en-US`). Both reads and writes
+/// go through [normalizeLocale] via this getter/setter, so no code path —
+/// initialization, [setLocale], or a direct `currentLocale = ...` assignment —
+/// can leave an un-normalized value.
+String get currentLocale => _currentLocale;
+set currentLocale(String value) => _currentLocale = normalizeLocale(value);
 
-void setLocale(String loc) {
-  currentLocale = loc;
+String getLocale() => currentLocale;
+
+void setLocale(String loc) => currentLocale = loc;
+
+/// Maps POSIX/special locales (`C`, `POSIX`), empty, or `und` to `en-US`, and
+/// normalizes the `_` separator to `-`. Use at locale entry points so these
+/// values fall back to en-US instead of being rejected as invalid.
+String normalizeLocale(String? locale) {
+  if (locale == null) {
+    return 'en-US';
+  }
+  final String lo = locale.replaceAll('_', '-');
+  if (lo.isEmpty || lo == 'C' || lo == 'POSIX') {
+    return 'en-US';
+  }
+  return lo;
 }
 
 String getJSONDataPath(String? locale) {

--- a/lib/internal/math_utils.dart
+++ b/lib/internal/math_utils.dart
@@ -1,0 +1,124 @@
+/// Math utilities mirroring JS MathUtils.js.
+///
+/// Includes rounding modes (halfdown, halfup, halfeven, halfodd, up, down,
+/// ceiling, floor), modular arithmetic, and numeric helpers.
+import 'dart:math' as math;
+
+/// Return the sign of the given number.
+/// Returns -1 if [number] is negative, 1 otherwise (including zero).
+int signum([dynamic value]) {
+  var n = value;
+
+  // If input is a string, parse to int
+  if (value is String) {
+    n = int.tryParse(value) ?? 0; // fallback to 0 if parse fails
+  } else if (value is! num) {
+    // If not a number and not a string, return 1
+    return 1;
+  }
+
+  // Return -1 if negative, otherwise 1
+  return (n < 0) ? -1 : 1;
+}
+
+
+/// Euclidean modulo. The result is always in the range [0, modulus).
+/// Unlike Dart's `%` operator which gives truncated division remainder,
+/// this always returns a non-negative result for positive modulus.
+num mod(num dividend, num modulus) {
+  if (modulus == 0) {
+    return 0;
+  }
+  final num x = dividend % modulus;
+  return x < 0 ? x + modulus : x;
+}
+
+/// Adjusted modulo. Like [mod] but returns values in the range (0, modulus].
+/// When the remainder is zero, [modulus] is returned instead.
+num amod(num dividend, num modulus) {
+  if (modulus == 0) {
+    return 0;
+  }
+  final num x = dividend % modulus;
+  return x <= 0 ? x + modulus : x;
+}
+
+/// Base-10 logarithm.
+double log10(double number) {
+  return math.log(number) / math.ln10;
+}
+
+/// Shift decimal by [precision] places (positive = right, negative = left).
+/// Avoids floating-point drift by using string-based "e" notation.
+double shiftDecimal(double number, int precision) {
+  final List<String> parts = number.toString().split('e');
+  final String base = parts[0];
+  final int existingExp = parts.length > 1 ? int.parse(parts[1]) : 0;
+  return double.parse('${base}e${existingExp + precision}');
+}
+
+/// Round using floor (toward negative infinity).
+double roundFloor(double num) => num.floorToDouble();
+
+/// Round using ceiling (toward positive infinity).
+double roundCeiling(double num) => num.ceilToDouble();
+
+/// Round toward zero (truncate).
+double roundDown(double num) => num < 0 ? num.ceilToDouble() : num.floorToDouble();
+
+/// Round away from zero.
+double roundUp(double num) => num < 0 ? num.floorToDouble() : num.ceilToDouble();
+
+/// Round half up (ties go away from zero).
+double roundHalfup(double num) =>
+    num < 0 ? (num - 0.5).ceilToDouble() : (num + 0.5).floorToDouble();
+
+/// Round half down (ties go toward zero).
+double roundHalfdown(double num) =>
+    num < 0 ? (num + 0.5).floorToDouble() : (num - 0.5).ceilToDouble();
+
+/// Round half even (banker's rounding — ties go to nearest even).
+double roundHalfeven(double num) =>
+    (num.floorToDouble() % 2 == 0) ? (num - 0.5).ceilToDouble() : (num + 0.5).floorToDouble();
+
+/// Round half odd (ties go to nearest odd).
+double roundHalfodd(double num) =>
+    (num.floorToDouble() % 2 != 0) ? (num - 0.5).ceilToDouble() : (num + 0.5).floorToDouble();
+
+/// Round half toward positive infinity (mirrors JS Math.round behavior).
+/// For positive numbers: ties go up. For negative numbers: ties go toward zero.
+double roundHalfPositiveInfinity(double num) => (num + 0.5).floorToDouble();
+
+/// Get rounding function by mode name.
+double Function(double) getRoundingFunction(String mode) {
+  switch (mode) {
+    case 'floor':
+      return roundFloor;
+    case 'ceiling':
+      return roundCeiling;
+    case 'down':
+      return roundDown;
+    case 'up':
+      return roundUp;
+    case 'halfup':
+      return roundHalfup;
+    case 'halfeven':
+      return roundHalfeven;
+    case 'halfodd':
+      return roundHalfodd;
+    case 'halfdown':
+    default:
+      return roundHalfdown;
+  }
+}
+
+/// Apply significant digits constraint.
+/// Mirrors JS MathUtils.significant(number, digits, round).
+double significant(double number, int digits, double Function(double) round) {
+  if (digits < 1 || number == 0) {
+    return number;
+  }
+  final double absNum = number.abs();
+  final int factor = -log10(absNum).floor() + digits - 1;
+  return shiftDecimal(round(shiftDecimal(number, factor)), -factor);
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -71,26 +71,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -127,10 +127,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
@@ -196,18 +196,18 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.7"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:
@@ -217,5 +217,5 @@ packages:
     source: hosted
     version: "15.0.0"
 sdks:
-  dart: ">=3.7.0-0 <4.0.0"
+  dart: ">=3.8.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/test/basic/flutter_ilib_math_utils_test.dart
+++ b/test/basic/flutter_ilib_math_utils_test.dart
@@ -1,0 +1,242 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_ilib/internal/math_utils.dart';
+
+void main() {
+  debugPrint('Testing [flutter_ilib_math_utils_test.dart] file.');
+  group('math_utils-mod', () {
+    test('testModSimple', () {
+      expect(mod(2, 4), 2);
+    });
+    test('testModWrap', () {
+      expect(mod(6, 4), 2);
+    });
+    test('testModWrapNeg', () {
+      expect(mod(-6, 4), 2);
+    });
+    test('testModZeroModulus', () {
+      expect(mod(6, 0), 0);
+    });
+    test('testModZeroNum', () {
+      expect(mod(0, 6), 0);
+    });
+    test('testModReal', () {
+      expect(mod(2.234231, 4), closeTo(2.234231, 0.0000001));
+    });
+    test('testModRealWrap', () {
+      expect(mod(6.234231, 4), closeTo(2.234231, 0.0000001));
+    });
+    test('testModRealNeg', () {
+      expect(mod(-6.3, 4), closeTo(1.7, 0.0000001));
+    });
+  });
+
+  group('math_utils-amod', () {
+    test('testAmodSimple', () {
+      expect(amod(2, 4), 2);
+    });
+    test('testAmodWrap', () {
+      expect(amod(6, 4), 2);
+    });
+    test('testAmodWrapNeg', () {
+      expect(amod(-6, 4), 2);
+    });
+    test('testAmodZeroModulus', () {
+      expect(amod(6, 0), 0);
+    });
+    test('testAmodZeroNum', () {
+      expect(amod(0, 6), 6);
+    });
+    test('testAmodReal', () {
+      expect(amod(2.234231, 4), closeTo(2.234231, 0.0000001));
+    });
+    test('testAmodRealWrap', () {
+      expect(amod(6.234231, 4), closeTo(2.234231, 0.0000001));
+    });
+    test('testAmodRealNeg', () {
+      expect(amod(-6.3, 4), closeTo(1.7, 0.0000001));
+    });
+  });
+
+  group('math_utils-log10', () {
+    test('testLog10', () {
+      expect(log10(12345.0).floor(), 4);
+    });
+    test('testLog10two', () {
+      expect(log10(987654321.0).floor(), 8);
+    });
+  });
+
+  group('math_utils-significant', () {
+    test('testSignificant1', () {
+      expect(significant(12345.0, 3, roundHalfup), 12300.0);
+    });
+    test('testSignificant2', () {
+      expect(significant(12345.0, 2, roundHalfup), 12000.0);
+    });
+    test('testSignificant3', () {
+      expect(significant(12345.0, 1, roundHalfup), 10000.0);
+    });
+    test('testSignificantZero', () {
+      expect(significant(12345.0, 0, roundHalfup), 12345.0);
+    });
+    test('testSignificantNegativeDigits', () {
+      expect(significant(12345.0, -234, roundHalfup), 12345.0);
+    });
+    test('testSignificantNegativeNumber', () {
+      // JS Math.round rounds ties toward positive infinity
+      expect(significant(-12345.0, 4, roundHalfPositiveInfinity), -12340.0);
+    });
+    test('testSignificantStradleDecimal', () {
+      expect(significant(12.345, 4, roundHalfup), 12.35);
+    });
+    test('testSignificantLessThanOne', () {
+      expect(significant(0.123456, 2, roundHalfup), 0.12);
+    });
+    test('testSignificantLessThanOneRound', () {
+      expect(significant(0.123456, 4, roundHalfup), 0.1235);
+    });
+    test('testSignificantLessThanOneSmall', () {
+      expect(significant(0.000123456, 2, roundHalfup), 0.00012);
+    });
+    test('testSignificantZeroNumber', () {
+      expect(significant(0.0, 2, roundHalfup), 0.0);
+    });
+  });
+
+  group('math_utils-signum', () {
+    test('testSignumPositive', () {
+      expect(signum(1), 1);
+    });
+    test('testSignumPositiveLarge', () {
+      expect(signum(1345234), 1);
+    });
+    test('testSignumNegative', () {
+      expect(signum(-1), -1);
+    });
+    test('testSignumNegativeLarge', () {
+      expect(signum(-13234), -1);
+    });
+    test('testSignumZero', () {
+      expect(signum(0), 1);
+    });
+    test('testSignumStringNumberPositive', () {
+      expect(signum("1345234"), 1);
+    });
+    test('testSignumStringNumberNegative', () {
+      expect(signum("-1345234"), -1);
+    });
+    test('testSignumUndefined', () {
+      expect(signum(), 1);
+    });
+    test('testSignumNull', () {
+      expect(signum(null), 1);
+    });
+    test('testSignumStringNonNumber', () {
+      expect(signum("rafgasdf"), 1);
+    });
+    test('testSignumBoolean', () {
+      expect(signum(true), 1);
+      expect(signum(false), 1);
+    });
+    test('testSignumFunction', () {
+      expect(signum(() { return -4; }), 1);
+    });
+  });
+
+  group('math_utils-shiftDecimal', () {
+    test('shift right', () {
+      expect(shiftDecimal(1.23, 2), 123.0);
+    });
+    test('shift left', () {
+      expect(shiftDecimal(123.0, -2), 1.23);
+    });
+    test('shift zero precision', () {
+      expect(shiftDecimal(1.5, 0), 1.5);
+    });
+    test('shift large precision', () {
+      expect(shiftDecimal(1.0, 5), 100000.0);
+    });
+  });
+
+  group('math_utils-rounding functions', () {
+    test('roundFloor positive', () {
+      expect(roundFloor(2.3), 2.0);
+    });
+    test('roundFloor negative', () {
+      expect(roundFloor(-2.3), -3.0);
+    });
+    test('roundCeiling positive', () {
+      expect(roundCeiling(2.3), 3.0);
+    });
+    test('roundCeiling negative', () {
+      expect(roundCeiling(-2.3), -2.0);
+    });
+    test('roundDown positive', () {
+      expect(roundDown(2.9), 2.0);
+    });
+    test('roundDown negative', () {
+      expect(roundDown(-2.9), -2.0);
+    });
+    test('roundUp positive', () {
+      expect(roundUp(2.1), 3.0);
+    });
+    test('roundUp negative', () {
+      expect(roundUp(-2.1), -3.0);
+    });
+    test('roundHalfup positive tie', () {
+      expect(roundHalfup(2.5), 3.0);
+    });
+    test('roundHalfup negative tie', () {
+      expect(roundHalfup(-2.5), -3.0);
+    });
+    test('roundHalfdown positive tie', () {
+      expect(roundHalfdown(2.5), 2.0);
+    });
+    test('roundHalfdown negative tie', () {
+      expect(roundHalfdown(-2.5), -2.0);
+    });
+    test('roundHalfeven even floor tie', () {
+      expect(roundHalfeven(2.5), 2.0);
+    });
+    test('roundHalfeven odd floor tie', () {
+      expect(roundHalfeven(3.5), 4.0);
+    });
+    test('roundHalfodd even floor tie', () {
+      expect(roundHalfodd(2.5), 3.0);
+    });
+    test('roundHalfodd odd floor tie', () {
+      expect(roundHalfodd(3.5), 3.0);
+    });
+  });
+
+  group('math_utils-getRoundingFunction', () {
+    test('floor', () {
+      expect(getRoundingFunction('floor'), roundFloor);
+    });
+    test('ceiling', () {
+      expect(getRoundingFunction('ceiling'), roundCeiling);
+    });
+    test('down', () {
+      expect(getRoundingFunction('down'), roundDown);
+    });
+    test('up', () {
+      expect(getRoundingFunction('up'), roundUp);
+    });
+    test('halfup', () {
+      expect(getRoundingFunction('halfup'), roundHalfup);
+    });
+    test('halfdown', () {
+      expect(getRoundingFunction('halfdown'), roundHalfdown);
+    });
+    test('halfeven', () {
+      expect(getRoundingFunction('halfeven'), roundHalfeven);
+    });
+    test('halfodd', () {
+      expect(getRoundingFunction('halfodd'), roundHalfodd);
+    });
+    test('default is halfdown', () {
+      expect(getRoundingFunction('unknown'), roundHalfdown);
+    });
+  });
+}

--- a/test/basic/flutter_ilib_numfmt_test.dart
+++ b/test/basic/flutter_ilib_numfmt_test.dart
@@ -4,10 +4,10 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
-  debugPrint('Testing [numfmt3_test.dart] file.');
+  debugPrint('Testing [flutter_ilib_numfmt_test.dart] file.');
   setUpAll(() async {
-    final ILibJS ilibjsinstance = ILibJS.instance;
-    await ilibjsinstance.loadJS();
+    await ILibLoader.instance.loadJSON();
+    await ILibLoader.instance.loadILibLocaleDataAll();
   });
 
   group('iLibNumFmt-format()', () {

--- a/test/basic/flutter_ilib_utils_test.dart
+++ b/test/basic/flutter_ilib_utils_test.dart
@@ -6,7 +6,7 @@ const String _base = 'packages/flutter_ilib/assets/locale';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
-  debugPrint('Testing [flutter_ilib_test.dart] file.');
+  debugPrint('Testing [flutter_ilib_utils_test.dart] file.');
   setUpAll(() async {});
 
   group('utils', () {

--- a/test/integration/example_app_api_test.dart
+++ b/test/integration/example_app_api_test.dart
@@ -1,0 +1,191 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_ilib/flutter_ilib.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Integration test that verifies the example app's "Current Time" and
+/// "DateTime (full)" produce matching results when locale is en-US.
+///
+/// Both use the same ILibDateFmtOptions (locale: 'en-US', length: 'full',
+/// type: 'datetime', useNative: false, timezone: 'local') with the same
+/// DateTime input, so the formatted output must be identical.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  debugPrint('Testing [example_app_integration_test.dart] file.');
+  setUpAll(() async {
+    await ILibLoader.instance.loadJSON();
+    await ILibLoader.instance.loadILibLocaleData('en-US');
+    await ILibLoader.instance.loadILibLocaleData('de-DE');
+    await ILibLoader.instance.loadILibLocaleData('ko-KR');
+  });
+
+  group('Version', () {
+    test('iLib version', () {
+      final FlutterILib plugin = FlutterILib.instance;
+      final String? version = plugin.getILibVersion;
+
+      expect(version, isNotNull);
+      expect(version!.isNotEmpty, true);
+      expect(version, equals('14.22.0'));
+      debugPrint('  iLib Version: $version');
+    });
+
+    test('CLDR version', () {
+      final FlutterILib plugin = FlutterILib.instance;
+      final String? cldrVersion = plugin.getCLDRVersion;
+
+      expect(cldrVersion, isNotNull);
+      expect(cldrVersion!.isNotEmpty, true);
+      expect(cldrVersion, equals('48.2'));
+      debugPrint('  CLDR Version: $cldrVersion');
+    });
+  });
+
+  group('DateFmt', () {
+    test('en-US full datetime (fixed)', () {
+      // Use a fixed DateTime for deterministic testing.
+      final DateTime now = DateTime(2026, 5, 29, 14, 30, 0);
+      final ILibDateOptions dateOptions = ILibDateOptions(dateTime: now);
+
+      // "Current Time" field - always uses en-US
+      final ILibDateFmtOptions currentTimeFmtOptions = ILibDateFmtOptions(
+          locale: 'en-US',
+          length: 'full',
+          type: 'datetime',
+          useNative: false,
+          timezone: 'local');
+      final ILibDateFmt currentTimeFmt = ILibDateFmt(currentTimeFmtOptions);
+      final String currentTimeResult = currentTimeFmt.format(dateOptions);
+
+      // "DateTime (full)" field - uses curLocale which is en-US
+      final ILibDateFmtOptions dateTimeFullFmtOptions = ILibDateFmtOptions(
+          locale: 'en-US',
+          length: 'full',
+          type: 'datetime',
+          useNative: false,
+          timezone: 'local');
+      final ILibDateFmt dateTimeFullFmt = ILibDateFmt(dateTimeFullFmtOptions);
+      final String dateTimeFullResult = dateTimeFullFmt.format(dateOptions);
+
+      // Both should produce the same result
+      expect(currentTimeResult, equals(dateTimeFullResult));
+
+      // Verify the format looks correct for en-US full datetime
+      // Note: iLib uses U+202F (Narrow No-Break Space) before AM/PM
+      expect(currentTimeResult, contains('May 29, 2026'));
+      expect(currentTimeResult, contains('2:30'));
+      expect(currentTimeResult, contains('PM'));
+      debugPrint('  Current Time (en-US): $currentTimeResult');
+      debugPrint('  DateTime (full) en-US: $dateTimeFullResult');
+    });
+
+    test('en-US full datetime (now)', () {
+      // Use DateTime.now() just like the example app does
+      final DateTime now = DateTime.now();
+      final ILibDateOptions dateOptions = ILibDateOptions(dateTime: now);
+
+      // "Current Time" - getDateTimeFormatNow('en-US')
+      final ILibDateFmtOptions currentTimeFmtOptions = ILibDateFmtOptions(
+          locale: 'en-US',
+          length: 'full',
+          type: 'datetime',
+          useNative: false,
+          timezone: 'local');
+      final ILibDateFmt currentTimeFmt = ILibDateFmt(currentTimeFmtOptions);
+      final String currentTimeResult = currentTimeFmt.format(dateOptions);
+
+      // "DateTime (full)" - getDateTimeFormat('en-US')
+      final ILibDateFmtOptions dateTimeFullFmtOptions = ILibDateFmtOptions(
+          locale: 'en-US',
+          length: 'full',
+          type: 'datetime',
+          useNative: false,
+          timezone: 'local');
+      final ILibDateFmt dateTimeFullFmt = ILibDateFmt(dateTimeFullFmtOptions);
+      final String dateTimeFullResult = dateTimeFullFmt.format(dateOptions);
+
+      // They must be identical
+      expect(currentTimeResult, equals(dateTimeFullResult));
+
+      // Verify it contains AM or PM (12-hour format for en-US)
+      expect(currentTimeResult, matches(RegExp(r'(AM|PM)')));
+      debugPrint('  Current Time (en-US): $currentTimeResult');
+      debugPrint('  DateTime (full) en-US: $dateTimeFullResult');
+    });
+
+    test('en-US full datetime pattern', () {
+      final ILibDateOptions dateOptions = ILibDateOptions(
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+
+      final ILibDateFmtOptions fmtOptions = ILibDateFmtOptions(
+          locale: 'en-US',
+          length: 'full',
+          type: 'datetime',
+          useNative: false,
+          timezone: 'local');
+      final ILibDateFmt fmt = ILibDateFmt(fmtOptions);
+      final String result = fmt.format(dateOptions);
+
+      // U+202F (Narrow No-Break Space) is used before AM/PM in CLDR data.
+      expect(result, equals('September 29, 2011 at 1:45 PM'));
+      debugPrint('  DateTime (full) en-US: $result');
+    });
+
+    test('en-US vs ko-KR full datetime', () async {
+      final ILibDateOptions dateOptions = ILibDateOptions(
+          year: 2026,
+          month: 5,
+          day: 29,
+          hour: 14,
+          minute: 30,
+          second: 0,
+          millisecond: 0);
+
+      // "Current Time" - always en-US
+      final ILibDateFmtOptions currentTimeFmtOptions = ILibDateFmtOptions(
+          locale: 'en-US',
+          length: 'full',
+          type: 'datetime',
+          useNative: false,
+          timezone: 'local');
+      final ILibDateFmt currentTimeFmt = ILibDateFmt(currentTimeFmtOptions);
+      final String currentTimeResult = currentTimeFmt.format(dateOptions);
+
+      // "DateTime (full)" - uses ko-KR
+      final ILibDateFmtOptions dateTimeFullFmtOptions = ILibDateFmtOptions(
+          locale: 'ko-KR',
+          length: 'full',
+          type: 'datetime',
+          useNative: false,
+          timezone: 'local');
+      final ILibDateFmt dateTimeFullFmt = ILibDateFmt(dateTimeFullFmtOptions);
+      final String dateTimeFullResult = dateTimeFullFmt.format(dateOptions);
+
+      // They should NOT be equal when locales differ
+      expect(dateTimeFullResult, isNot(equals(currentTimeResult)));
+
+      // U+202F (Narrow No-Break Space) is used before AM/PM in CLDR data.
+      expect(currentTimeResult, equals('May 29, 2026 at 2:30 PM'));
+      expect(dateTimeFullResult, equals('2026년 5월 29일 오후 2:30'));
+
+      debugPrint('  Current Time (en-US): $currentTimeResult');
+      debugPrint('  DateTime (full) ko-KR: $dateTimeFullResult');
+    });
+  });
+
+  group('NumFmt', () {
+    test('de-DE number format', () async {
+      // Same logic as example app's getNumFmt()
+      final ILibNumFmt fmt = ILibNumFmt(ILibNumFmtOptions(locale: 'de-DE'));
+      final String result = fmt.format(-111123456.785);
+
+      expect(result, equals('-111.123.456,785'));
+      debugPrint('  Number Format (de-DE): $result');
+    });
+  });
+}


### PR DESCRIPTION
### Checklist

The following lists affects Pub Points on pub.dev when the package is published.
* [ ] Passed the all tests.
* [ ] Verified that the example app works.
* [ ] Executed the `dart format` command.
* [ ] Added the API description is added if necessary.

### Description
* Implement `ILibNumFmt` and math_utils
  * `ilib_numfmt.dart`, `math_utils.dart`
* Update example app including numfmt and fixed datetime
* Add example integration test
* Update execute_unit_test.sh to support integration test
  * Usage for integration test
./execute_unit_test.sh # Run all tests (default)
./execute_unit_test.sh unit # Run library API tests only
./execute_unit_test.sh integration # Run example app tests only