### PR TITLE
[migration/ilib-js-to-dart] fix: normalize C/POSIX/und locale to en-US; read astro from root data

### DIFF
--- a/lib/calendar/ilib_astro.dart
+++ b/lib/calendar/ilib_astro.dart
@@ -3,7 +3,6 @@ import 'dart:math';
 import 'package:flutter/foundation.dart' show visibleForTesting;
 
 import '../ilib_init.dart';
-import '../internal/ilib_utils.dart';
 import 'greg_rata_die.dart';
 
 class ILibAstro {
@@ -12,14 +11,19 @@ class ILibAstro {
   static Map<String, dynamic>? _data;
 
   static Map<String, dynamic> _getData() {
-    if (_data != null) {
+    // astro is locale-independent (root.json only). Read it from the root data
+    // directly so it does not depend on currentLocale being valid/loaded, and
+    // never cache an empty map (so a too-early call can recover later).
+    if (_data != null && _data!.isNotEmpty) {
       return _data!;
     }
-    final Map<String, dynamic>? localeData =
-        ILibLoader.instance.getLocaleData(currentLocale);
-    _data = (localeData?['ilib.data.astro'] as Map<String, dynamic>?) ??
-        <String, dynamic>{};
-    return _data!;
+    final Map<String, dynamic>? rootData = ILibLoader.instance.getRootData();
+    final Map<String, dynamic>? astro =
+        rootData?['ilib.data.astro'] as Map<String, dynamic>?;
+    if (astro != null && astro.isNotEmpty) {
+      _data = astro;
+    }
+    return astro ?? const <String, dynamic>{};
   }
 
   static double _dtr(double d) => d * pi / 180.0;

--- a/lib/ilib_init.dart
+++ b/lib/ilib_init.dart
@@ -29,9 +29,19 @@ class ILibLoader extends ChangeNotifier {
 
   final Set<String> _availableAssets = <String>{};
 
+  static const String _rootPath =
+      'packages/flutter_ilib/assets/locale/root.json';
+
   Map<String, dynamic>? getLocaleData(String locale) {
     return _localeDataMap[locale] ?? _mergeFromCache(locale);
   }
+
+  /// Locale-independent data from root.json (e.g. `ilib.data.astro`).
+  ///
+  /// root.json is always loaded first by [loadJSON], so this is available
+  /// regardless of which locales have been loaded — unlike [getLocaleData],
+  /// which depends on a (valid, loaded) locale.
+  Map<String, dynamic>? getRootData() => _fileDataCache[_rootPath];
 
   Map<String, dynamic>? _mergeFromCache(String locale) {
     final List<String> paths = getJSONDataPaths(locale);
@@ -130,14 +140,15 @@ class ILibLoader extends ChangeNotifier {
     await _loadAssetManifest();
 
     // Always load root.json first as it contains locale-independent data (e.g. astro)
-    await _loadFile('packages/flutter_ilib/assets/locale/root.json');
+    await _loadFile(_rootPath);
 
-    final String curlocale = getLocale();
-    if (isValidLocale(curlocale)) {
-      await _loadLocaleData(curlocale);
-    } else {
-      logger.warn('Invalid locale: $curlocale, no locale-specific data loaded');
+    // normalizeLocale maps C/POSIX/empty to en-US.
+    String curlocale = normalizeLocale(getLocale());
+    if (!isValidLocale(curlocale)) {
+      logger.warn('Invalid locale: $curlocale, falling back to en-US');
+      curlocale = 'en-US';
     }
+    await _loadLocaleData(curlocale);
 
     initILib();
     logger.info('Notifying listeners after JSON loading');
@@ -161,7 +172,8 @@ class ILibLoader extends ChangeNotifier {
       return;
     }
 
-    locale ??= getLocale();
+    // normalizeLocale maps C/POSIX/empty to en-US instead of rejecting.
+    locale = normalizeLocale(locale ?? getLocale());
     if (!isValidLocale(locale)) {
       return;
     }

--- a/lib/internal/ilib_utils.dart
+++ b/lib/internal/ilib_utils.dart
@@ -2,15 +2,38 @@ import 'dart:ui';
 
 import '../ilib_locale.dart';
 
-String currentLocale =
-    PlatformDispatcher.instance.locale.toString().replaceAll('_', '-');
+String _currentLocale =
+    normalizeLocale(PlatformDispatcher.instance.locale.toString());
 
-String getLocale() {
-  return currentLocale;
-}
+/// The active locale, always normalized — it can never be observed as
+/// `C`/`POSIX`/empty (those collapse to `en-US`). Both reads and writes go
+/// through [normalizeLocale] via this getter/setter, so no code path —
+/// initialization, [setLocale], or a direct `currentLocale = ...` assignment —
+/// can leave an un-normalized value.
+String get currentLocale => _currentLocale;
+set currentLocale(String value) => _currentLocale = normalizeLocale(value);
 
-void setLocale(String loc) {
-  currentLocale = loc;
+String getLocale() => currentLocale;
+
+void setLocale(String loc) => currentLocale = loc;
+
+/// Maps "no real locale" values to `en-US` and normalizes the `_` separator
+/// to `-`. Covers POSIX/special locales (`C`, `POSIX`), empty/null, and the
+/// BCP-47 "undetermined" code `und` (which some embedders — e.g. embedded
+/// targets like webOS — report when the platform locale is unknown; on its own
+/// it would only load root defaults, not a usable locale).
+///
+/// Only the bare `und` collapses — `und-US`/`und-Hans` (valid region/script
+/// fallbacks, built internally by [getJSONDataPaths]) are left untouched.
+String normalizeLocale(String? locale) {
+  if (locale == null) {
+    return 'en-US';
+  }
+  final String lo = locale.replaceAll('_', '-');
+  if (lo.isEmpty || lo == 'C' || lo == 'POSIX' || lo == 'und') {
+    return 'en-US';
+  }
+  return lo;
 }
 
 String getJSONDataPath(String? locale) {

--- a/test/basic/flutter_ilib_utils_test.dart
+++ b/test/basic/flutter_ilib_utils_test.dart
@@ -111,4 +111,39 @@ void main() {
       expect(paths.length, 7);
     });
   });
+
+  group('normalizeLocale', () {
+    test('C / POSIX / und / empty / null fall back to en-US', () {
+      expect(normalizeLocale('C'), 'en-US');
+      expect(normalizeLocale('POSIX'), 'en-US');
+      expect(normalizeLocale('und'), 'en-US'); // bare "undetermined"
+      expect(normalizeLocale(''), 'en-US');
+      expect(normalizeLocale(null), 'en-US');
+    });
+
+    test('normalizes the separator and keeps valid locales', () {
+      expect(normalizeLocale('ko_KR'), 'ko-KR');
+      expect(normalizeLocale('fa-IR'), 'fa-IR');
+      expect(normalizeLocale('en-US'), 'en-US');
+    });
+
+    test('keeps und-REGION / und-SCRIPT (only bare und collapses)', () {
+      expect(normalizeLocale('und-US'), 'und-US');
+      expect(normalizeLocale('und-Hans'), 'und-Hans');
+    });
+  });
+
+  group('currentLocale is always normalized', () {
+    test('setLocale and direct assignment both normalize', () {
+      final String saved = getLocale();
+      setLocale('C');
+      expect(currentLocale, 'en-US');
+      expect(getLocale(), 'en-US');
+      currentLocale = 'POSIX'; // direct assignment also goes through the setter
+      expect(currentLocale, 'en-US');
+      currentLocale = 'ko_KR';
+      expect(currentLocale, 'ko-KR');
+      setLocale(saved); // restore the shared global
+    });
+  });
 }

--- a/test/calendar/testastro_extra_test.dart
+++ b/test/calendar/testastro_extra_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_ilib/flutter_ilib.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// flutter_ilib-specific (no JS counterpart): `ilib.data.astro` is locale-
+// independent and lives only in root.json, so it is read from the root data
+// directly (ILibLoader.getRootData) rather than via getLocaleData(currentLocale).
+// This is the regression guard for the Persian/equinox crash that happened when
+// the active locale had no astro-bearing data (`null as List` in equinox).
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  setUpAll(() async {
+    await ILibLoader.instance.loadJSON();
+  });
+
+  test('getRootData exposes locale-independent astro coefficients', () {
+    final Map<String, dynamic>? root = ILibLoader.instance.getRootData();
+    expect(root, isNotNull);
+    expect(root!['ilib.data.astro'], isA<Map<String, dynamic>>());
+
+    final Map<String, dynamic>? astro =
+        root['ilib.data.astro'] as Map<String, dynamic>?;
+    // The coefficient tables the equinox calculation indexes into.
+    expect(astro!['_JDE0tab2000'], isA<List<dynamic>>());
+    expect(astro['_JDE0tab1000'], isA<List<dynamic>>());
+    expect(astro['_EquinoxpTerms'], isA<List<dynamic>>());
+  });
+
+  test('equinox resolves astro from root regardless of the active locale', () {
+    // Only root + the system locale are loaded above; no Persian locale data
+    // is loaded. equinox must still compute (astro comes from root.json) and
+    // not throw `null as List`.
+    final double jd = ILibAstro.equinox(2026, 0);
+    expect(jd, isA<double>());
+    expect(jd, greaterThan(2400000.0)); // a plausible Julian Day
+  });
+}


### PR DESCRIPTION
### Checklist

The following lists affects Pub Points on pub.dev when the package is published.
* [ ] Passed the all tests.
* [ ] Verified that the example app works.
* [ ] Executed the `dart format` command.
* [ ] Added the API description is added if necessary.

## Summary
A POSIX/undetermined platform locale crashed Persian (equinox) date formatting,
and the active locale wasn't normalized consistently. This normalizes such
locales to `en-US` everywhere and makes the astronomical data locale-independent.

## Problem
- On some platforms the device locale resolves to `C`/`POSIX` (Linux desktop) or
  `und` (undetermined — common on embedders like webOS).
- That value flowed into `currentLocale` un-normalized, so `ILibAstro._getData()`
  fetched `ilib.data.astro` via `getLocaleData(currentLocale)`, got no data, and
  **cached the empty result permanently** → every Persian/equinox calc then threw
  `null as List` in `ILibAstro.equinox`.

## Changes
- **`ilib_utils`**: add `normalizeLocale()` mapping `C`/`POSIX`/`und`/empty/`null`
  → `en-US` (only bare `und`; `und-US`/`und-Hans` fallbacks preserved). Make
  `currentLocale` a getter/setter so every read/write is normalized — no code
  path (init, `setLocale`, direct assignment) can observe `C`/`und`.
- **`ilib_init`**: apply `normalizeLocale` in `loadJSON` / `loadILibLocaleData`
  (so an undetermined/POSIX locale loads `en-US`, not root-only data); add a
  `getRootData()` accessor + `_rootPath` constant.
- **`ilib_astro`**: read `ilib.data.astro` from `ILibLoader.getRootData()`
  (root.json, locale-independent) instead of `getLocaleData(currentLocale)`, and
  never cache an empty map so a too-early call can recover.

## Tests
- `flutter_ilib_utils_test`: `normalizeLocale` (C/POSIX/und/empty/null → en-US;
  und-US/und-Hans preserved) and `currentLocale` always-normalized.
- `testastro_extra_test` (new): `getRootData()` exposes astro coefficients;
  `equinox()` resolves astro from root regardless of the active locale.

## Verification
`flutter analyze` clean; astro / Persian / utils test suites pass.
