### PR TITLE
[migration/ilib-js-to-dart] add missing ku-Arab-IQ numfmt tests in iLIbLocaleInfo, clarify unsupported-locale rule, drop dead floor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,10 +193,9 @@ lib/
   scope only if its locale is in that list. When the data is fully absent,
   `ILibLocaleInfo`/`ILibTimeZone.fromLocale` fall back to defaults (e.g. `Etc/UTC`), so the
   test cannot reproduce the JS expected value — these are N/A.
-  **Do not decide by "the value happens to reproduce":** an unsupported
-  locale can still yield the JS value by language fallback (e.g. `ku-IQ` via `ku` + `und-IQ`), yet
-  it is out of scope; only convert the variant that is in `locales.json` (e.g. `ku-Arab-IQ` is,
-  `ku-IQ`/`ku-TR` are not). See [docs/conversion-guide.md](docs/conversion-guide.md) › Test Conversion.
+  **Do not decide by "the value happens to reproduce":** an unsupported locale can still yield the
+  JS value by language fallback, yet it is out of scope — only convert the variant that is in
+  `locales.json`. See [docs/conversion-guide.md](docs/conversion-guide.md) › Test Conversion.
 
 ### Public API Export
 - All public classes exported from `lib/flutter_ilib.dart`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,12 +187,17 @@ lib/
   JS counterpart (Dart-specific: extra accessors like getDayOfYear/getEra, `'local'`/
   system-tz, offset variants) go in a sibling `*_extra_test.dart`** — never add Dart-only
   cases to the JS-mirrored file (see docs/conversion-guide.md, docs/test-mapping.md)
-- **Do NOT convert JS tests that exercise a locale not in the bundled set under
-  `assets/locale/`** (the 218 bundled iLib locales — see Source Versions). Without the locale data,
+- **Do NOT convert JS tests for a locale that flutter_ilib does not support.** The authoritative
+  list of supported locales is `scripts/assemble_ilib/locales.json` (the seed used to generate
+  `assets/locale/` — the 218 bundled iLib locales, see Source Versions); a per-locale test is in
+  scope only if its locale is in that list. When the data is fully absent,
   `ILibLocaleInfo`/`ILibTimeZone.fromLocale` fall back to defaults (e.g. `Etc/UTC`), so the
-  test cannot reproduce the JS expected value — these are N/A. (e.g. JS
+  test cannot reproduce the JS expected value — these are N/A (e.g. JS
   `testTZGetDefaultFor_tk_TM`/`_tg_TJ`/`_wo_SN`/`_zu_ZA`/`_mt_MT` — tk/tg/wo/zu/mt and their
-  regions are not bundled.)
+  regions are not bundled). **Do not decide by "the value happens to reproduce":** an unsupported
+  locale can still yield the JS value by language fallback (e.g. `ku-IQ` via `ku` + `und-IQ`), yet
+  it is out of scope; only convert the variant that is in `locales.json` (e.g. `ku-Arab-IQ` is,
+  `ku-IQ`/`ku-TR` are not). See [docs/conversion-guide.md](docs/conversion-guide.md) › Test Conversion.
 
 ### Public API Export
 - All public classes exported from `lib/flutter_ilib.dart`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,9 +192,8 @@ lib/
   `assets/locale/` — the 218 bundled iLib locales, see Source Versions); a per-locale test is in
   scope only if its locale is in that list. When the data is fully absent,
   `ILibLocaleInfo`/`ILibTimeZone.fromLocale` fall back to defaults (e.g. `Etc/UTC`), so the
-  test cannot reproduce the JS expected value — these are N/A (e.g. JS
-  `testTZGetDefaultFor_tk_TM`/`_tg_TJ`/`_wo_SN`/`_zu_ZA`/`_mt_MT` — tk/tg/wo/zu/mt and their
-  regions are not bundled). **Do not decide by "the value happens to reproduce":** an unsupported
+  test cannot reproduce the JS expected value — these are N/A.
+  **Do not decide by "the value happens to reproduce":** an unsupported
   locale can still yield the JS value by language fallback (e.g. `ku-IQ` via `ku` + `und-IQ`), yet
   it is out of scope; only convert the variant that is in `locales.json` (e.g. `ku-Arab-IQ` is,
   `ku-IQ`/`ku-TR` are not). See [docs/conversion-guide.md](docs/conversion-guide.md) › Test Conversion.

--- a/docs/conversion-guide.md
+++ b/docs/conversion-guide.md
@@ -82,7 +82,9 @@ String getClock() {
 - [ ] **NEVER modify test expected values** — if a test fails, the Dart implementation has a bug, not the test data
 - [ ] Test data (e.g., `testDatesCoptic` reference arrays) must match JS source exactly
 - [ ] If a JS test cannot be converted due to missing Dart features (setters, timezone offset), document it in `docs/test-mapping.md` under "Not Converted" with the reason
-- [ ] **Do NOT convert JS tests that use a locale not bundled under `assets/locale/`** (the bundled iLib locales — see CLAUDE.md › Source Versions). The data is absent, so `ILibLocaleInfo`/`ILibTimeZone.fromLocale` fall back to defaults (e.g. `Etc/UTC`) and the JS expected value (e.g. `Asia/Ashgabat`) cannot be reproduced — N/A (e.g. `testTZGetDefaultFor_tk_TM`/`_tg_TJ`/`_wo_SN`/`_zu_ZA`/`_mt_MT`)
+- [ ] **Do NOT convert JS tests for a locale that flutter_ilib does not support.** The authoritative list of supported locales is `scripts/assemble_ilib/locales.json` (the seed used to generate `assets/locale/`) — a per-locale test is in scope only if its locale is in that list.
+  - When the data is fully absent, `ILibLocaleInfo`/`ILibTimeZone.fromLocale` fall back to defaults (e.g. `Etc/UTC`) and the JS expected value (e.g. `Asia/Ashgabat`) cannot be reproduced — N/A (e.g. `testTZGetDefaultFor_tk_TM`/`_tg_TJ`/`_wo_SN`/`_zu_ZA`/`_mt_MT`).
+  - **Do not rely on "the value happens to reproduce" to decide.** An unsupported locale can still produce the JS value by language fallback (e.g. `ku-IQ` resolves via `ku` + `und-IQ`), yet it is out of scope because it is not in `locales.json`. Conversely, only convert the supported variant (e.g. `ku-Arab-IQ` **is** in the list; `ku-IQ`/`ku-TR` are not). Membership in `locales.json` — not data presence or accidental fallback — is the test.
 - [ ] Dart-specific additional tests (getDayOfYear, getEra, etc.) go in a separate `*_extra_test.dart` file
 
 ### 5. Cleanup

--- a/lib/calendar/calendar_utils.dart
+++ b/lib/calendar/calendar_utils.dart
@@ -14,7 +14,3 @@ int floorDiv(int a, int b) {
   }
   return q;
 }
-
-int floorMod(int a, int b) {
-  return a - floorDiv(a, b) * b;
-}

--- a/test/localeinfo/localeinfo_test.dart
+++ b/test/localeinfo/localeinfo_test.dart
@@ -210,7 +210,6 @@ void main() {
 
       expect(info.getDecimalSeparator(), ',');
     });
-    //*************************************************Added By Birendra 23/05**********************************************************
     //test cases for en-GB number format
     test('testLocaleInfoGetDecimalSeparatorfor_en_GB', () {
       final ILibLocaleInfo info = ILibLocaleInfo('en-GB');
@@ -2975,6 +2974,66 @@ void main() {
     });
     test('testLocaleInfoRoundingMode_ku', () {
       final ILibLocaleInfo info = ILibLocaleInfo('ku-IQ');
+      expect(info, isNotNull);
+
+      expect(info.getRoundingMode(), 'halfdown');
+    });
+    //test cases for ku-Arab-IQ
+    test('testLocaleInfoGetDecimalSeparatorfor_ku_Arab_IQ', () {
+      final ILibLocaleInfo info = ILibLocaleInfo('ku-Arab-IQ');
+      expect(info, isNotNull);
+      expect(info.getDecimalSeparator(), '.');
+    });
+    test('testLocaleInfoGetGroupingSeparatorfor_ku_Arab_IQ', () {
+      final ILibLocaleInfo info = ILibLocaleInfo('ku-Arab-IQ');
+      expect(info, isNotNull);
+
+      expect(info.getGroupingSeparator(), ',');
+    });
+    test('testLocaleInfoGetPercentageFormat_ku_Arab_IQ', () {
+      final ILibLocaleInfo info = ILibLocaleInfo('ku-Arab-IQ');
+      expect(info, isNotNull);
+
+      expect(info.getPercentageFormat(), '{n}%');
+    });
+    test('testLocaleInfoGetCurrencyFormat_ku_Arab_IQ', () {
+      final ILibLocaleInfo info = ILibLocaleInfo('ku-Arab-IQ');
+      expect(info, isNotNull);
+
+      expect(info.getCurrencyFormats().common, '{s} {n}');
+    });
+    test('testLocaleInfoGetNegativeNumberFormat_ku_Arab_IQ', () {
+      final ILibLocaleInfo info = ILibLocaleInfo('ku-Arab-IQ');
+      expect(info, isNotNull);
+
+      expect(info.getNegativeNumberFormat(), '-{n}');
+    });
+    test('testLocaleInfoGetNegativePercentageFormat_ku_Arab_IQ', () {
+      final ILibLocaleInfo info = ILibLocaleInfo('ku-Arab-IQ');
+      expect(info, isNotNull);
+
+      expect(info.getNegativePercentageFormat(), '-{n}%');
+    });
+    test('testLocaleInfoGetNegativeCurrencyFormat_ku_Arab_IQ', () {
+      final ILibLocaleInfo info = ILibLocaleInfo('ku-Arab-IQ');
+      expect(info, isNotNull);
+
+      expect(info.getCurrencyFormats().commonNegative, '-{s} {n}');
+    });
+    test('testLocaleInfoGetPrimaryGroupingDigits_ku_Arab_IQ', () {
+      final ILibLocaleInfo info = ILibLocaleInfo('ku-Arab-IQ');
+      expect(info, isNotNull);
+
+      expect(info.getPrimaryGroupingDigits(), 3);
+    });
+    test('testLocaleInfoGetSecondaryGroupingDigits_ku_Arab_IQ', () {
+      final ILibLocaleInfo info = ILibLocaleInfo('ku-Arab-IQ');
+      expect(info, isNotNull);
+
+      expect(info.getSecondaryGroupingDigits(), 0);
+    });
+    test('testLocaleInfoRoundingMode_ku_Arab_IQ', () {
+      final ILibLocaleInfo info = ILibLocaleInfo('ku-Arab-IQ');
       expect(info, isNotNull);
 
       expect(info.getRoundingMode(), 'halfdown');


### PR DESCRIPTION
### Checklist

The following lists affects Pub Points on pub.dev when the package is published.
* [ ] Passed the all tests.
* [ ] Verified that the example app works.
* [ ] Executed the `dart format` command.
* [ ] Added the API description is added if necessary.

### Description
## Summary
Follow-up from auditing `ILibLocaleInfo` test-conversion coverage against the
iLib v14.22.0 source (`js/test/root/testlocaleinfo.js`).

### What & why
- **test(localeinfo): add the 10 missing `ku-Arab-IQ` number-format tests.**
  The JS source tests three ku variants — `ku-IQ`, `ku-Arab-IQ`, `ku-TR` — but
  only `ku-IQ` had been converted. `ku-Arab-IQ` is the one present in the
  supported-locale list (`scripts/assemble_ilib/locales.json`); `ku-IQ` and
  `ku-TR` are not. So this was a genuine gap, not an intentional skip.
  The bundled data (`ku` + `ku-Arab` + `und-IQ`) reproduces the JS expected
  values exactly. Currency `common` / `commonNegative` separators use U+00A0
  (NBSP), matching both the JS source and the bundled data.
- **docs: key the "skip unsupported-locale tests" rule to `locales.json`**
  (in `conversion-guide.md` and `CLAUDE.md`). The previous wording ("not bundled
  under `assets/locale/`") was ambiguous: an unsupported locale can still
  reproduce the JS value via language fallback (e.g. `ku-IQ` → `ku` + `und-IQ`),
  so "the value happens to reproduce" is not the criterion — membership in
  `locales.json` is.
- **chore(calendar): remove the unused `floorMod` helper.** It was never called
  anywhere in `lib/` or `test/` since it was introduced, and has no counterpart
  in the iLib JS `MathUtils` source.

## Test
- `flutter test test/localeinfo/localeinfo_test.dart` → 913 → **923** passing (0 failures)
- `flutter analyze` → no new issues in the added code