### PR TITLE
[migration/ilib-js-to-dart] test(datefmt): convert missing format() tests across 72 locales

### DIFF
--- a/test/datefmt/datefmt_af_ZA_test.dart
+++ b/test/datefmt/datefmt_af_ZA_test.dart
@@ -1349,5 +1349,24 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtConstructorEmpty_af_ZA', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(locale: 'af-ZA'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtTemplateCalendar_af_ZA', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'af-ZA', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'af-ZA',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
   });
 }

--- a/test/datefmt/datefmt_am_ET_test.dart
+++ b/test/datefmt/datefmt_am_ET_test.dart
@@ -1257,5 +1257,39 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtConstructorEmpty_am_ET', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(locale: 'am-ET'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtTemplateCalendar_am_ET', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'am-ET', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'am-ET',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
+    test('testDateFmtTemplateCalendarIncompatibleDateType_am_ET', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'am-ET', calendar: 'julian', template: 'yyyy-MM-dd HH:mm'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'am-ET',
+          calendar: 'ethiopic',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2019-05-24 19:45');
+    });
   });
 }

--- a/test/datefmt/datefmt_ar_EG_test.dart
+++ b/test/datefmt/datefmt_ar_EG_test.dart
@@ -1440,5 +1440,20 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '١٣:٤٥');
     });
+    test('testDateFmtTemplateCalendar_ar_EG', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'ar-EG', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'ar-EG',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '٢٠١١-٠٩-٢٩');
+    });
   });
 }

--- a/test/datefmt/datefmt_ar_SA_test.dart
+++ b/test/datefmt/datefmt_ar_SA_test.dart
@@ -1058,5 +1058,20 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '١٣:٤٥');
     });
+    test('testDateFmtTemplateCalendar_ar_SA', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'ar-SA', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'ar-SA',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '٢٠١١-٠٩-٢٩');
+    });
   });
 }

--- a/test/datefmt/datefmt_as_IN_test.dart
+++ b/test/datefmt/datefmt_as_IN_test.dart
@@ -1155,5 +1155,24 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '১৩:৪৫');
     });
+    test('testDateFmtINConstructorEmpty_as_IN', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(locale: 'as-IN'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtINTemplateCalendar_as_IN', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'as-IN', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'as-IN',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '২০১১-০৯-২৯');
+    });
   });
 }

--- a/test/datefmt/datefmt_az_Latn_AZ_test.dart
+++ b/test/datefmt/datefmt_az_Latn_AZ_test.dart
@@ -1060,5 +1060,25 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtConstructorEmpty_az_Latn_AZ', () {
+      final ILibDateFmt fmt =
+          ILibDateFmt(ILibDateFmtOptions(locale: 'az-Latn-AZ'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtTemplateCalendar_az_Latn_AZ', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'az-Latn-AZ', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'az-Latn-AZ',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
   });
 }

--- a/test/datefmt/datefmt_bg_test.dart
+++ b/test/datefmt/datefmt_bg_test.dart
@@ -1088,5 +1088,24 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtConstructorEmpty_bg_BG', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(locale: 'bg-BG'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtTemplateCalendar_bg_BG', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'bg-BG', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'bg-BG',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
   });
 }

--- a/test/datefmt/datefmt_bn_IN_test.dart
+++ b/test/datefmt/datefmt_bn_IN_test.dart
@@ -1073,5 +1073,24 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '১৩:৪৫');
     });
+    test('testDateFmtINConstructorEmpty_bn_IN', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(locale: 'bn-IN'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtINTemplateCalendar_bn_IN', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'bn-IN', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'bn-IN',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '২০১১-০৯-২৯');
+    });
   });
 }

--- a/test/datefmt/datefmt_bs_Latn_BA_test.dart
+++ b/test/datefmt/datefmt_bs_Latn_BA_test.dart
@@ -1085,5 +1085,25 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtConstructorEmpty_bs_Latn_BA', () {
+      final ILibDateFmt fmt =
+          ILibDateFmt(ILibDateFmtOptions(locale: 'bs-Latn-BA'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtTemplateCalendar_bs_Latn_BA', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'bs-Latn-BA', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'bs-Latn-BA',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
   });
 }

--- a/test/datefmt/datefmt_cs_CZ_test.dart
+++ b/test/datefmt/datefmt_cs_CZ_test.dart
@@ -962,5 +962,24 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtConstructorEmpty_cs_CZ', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(locale: 'cs-CZ'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtTemplateCalendar_cs_CZ', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'cs-CZ', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'cs-CZ',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
   });
 }

--- a/test/datefmt/datefmt_de_DE_test.dart
+++ b/test/datefmt/datefmt_de_DE_test.dart
@@ -1098,5 +1098,39 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtConstructorEmpty_de_DE', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(locale: 'de-DE'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtTemplateCalendar_de_DE', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'de-DE', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'de-DE',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
+    test('testDateFmtTemplateCalendarIncompatibleDateType_de_DE', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'de-DE', calendar: 'julian', template: 'yyyy-MM-dd HH:mm'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'de-DE',
+          calendar: 'gregorian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-16 13:45');
+    });
   });
 }

--- a/test/datefmt/datefmt_el_GR_test.dart
+++ b/test/datefmt/datefmt_el_GR_test.dart
@@ -962,5 +962,24 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtConstructorEmpty_el_GR', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(locale: 'el-GR'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtTemplateCalendar_el_GR', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'el-GR', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'el-GR',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
   });
 }

--- a/test/datefmt/datefmt_es_CO_test.dart
+++ b/test/datefmt/datefmt_es_CO_test.dart
@@ -1018,5 +1018,9 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtConstructorEmpty_es_CO', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(locale: 'es-CO'));
+      expect(fmt, isNotNull);
+    });
   });
 }

--- a/test/datefmt/datefmt_es_ES_test.dart
+++ b/test/datefmt/datefmt_es_ES_test.dart
@@ -1091,5 +1091,39 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtConstructorEmpty_es_ES', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(locale: 'es-ES'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtTemplateCalendar_es_ES', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'es-ES', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'es-ES',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
+    test('testDateFmtTemplateCalendarIncompatibleDateType_es_ES', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'es-ES', calendar: 'julian', template: 'yyyy-MM-dd HH:mm'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'es-ES',
+          calendar: 'gregorian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-16 13:45');
+    });
   });
 }

--- a/test/datefmt/datefmt_et_EE_test.dart
+++ b/test/datefmt/datefmt_et_EE_test.dart
@@ -963,5 +963,24 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtConstructorEmpty_et_EE', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(locale: 'et-EE'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtTemplateCalendar_et_EE', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'et-EE', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'et-EE',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
   });
 }

--- a/test/datefmt/datefmt_fa_IR_test.dart
+++ b/test/datefmt/datefmt_fa_IR_test.dart
@@ -1436,5 +1436,20 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '۱۳:۴۵');
     });
+    test('testDateFmtTemplateCalendar_fa_IR', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'fa-IR', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'fa-IR',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '۲۰۱۱-۰۹-۲۹');
+    });
   });
 }

--- a/test/datefmt/datefmt_fi_FI_test.dart
+++ b/test/datefmt/datefmt_fi_FI_test.dart
@@ -1059,5 +1059,24 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtConstructorEmpty_fi_FI', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(locale: 'fi-FI'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtTemplateCalendar_fi_FI', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'fi-FI', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'fi-FI',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
   });
 }

--- a/test/datefmt/datefmt_fr_FR_test.dart
+++ b/test/datefmt/datefmt_fr_FR_test.dart
@@ -1087,5 +1087,39 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtConstructorEmpty_fr_FR', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(locale: 'fr-FR'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtTemplateCalendar_fr_FR', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'fr-FR', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'fr-FR',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
+    test('testDateFmtTemplateCalendarIncompatibleDateType_fr_FR', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'fr-FR', calendar: 'julian', template: 'yyyy-MM-dd HH:mm'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'fr-FR',
+          calendar: 'gregorian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-16 13:45');
+    });
   });
 }

--- a/test/datefmt/datefmt_ga_IE_test.dart
+++ b/test/datefmt/datefmt_ga_IE_test.dart
@@ -985,5 +985,24 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtConstructorEmpty_ga_IE', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(locale: 'ga-IE'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtTemplateCalendar_ga_IE', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'ga-IE', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'ga-IE',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
   });
 }

--- a/test/datefmt/datefmt_gu_IN_test.dart
+++ b/test/datefmt/datefmt_gu_IN_test.dart
@@ -1050,5 +1050,24 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtINConstructorEmpty_gu_IN', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(locale: 'gu-IN'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtINTemplateCalendar_gu_IN', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'gu-IN', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'gu-IN',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
   });
 }

--- a/test/datefmt/datefmt_ha_Latn_NG_test.dart
+++ b/test/datefmt/datefmt_ha_Latn_NG_test.dart
@@ -1312,5 +1312,25 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtConstructorEmpty_ha_Latn', () {
+      final ILibDateFmt fmt =
+          ILibDateFmt(ILibDateFmtOptions(locale: 'ha-Latn-NG'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtTemplateCalendar_ha_Latn', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'ha-Latn-NG', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'ha-Latn-NG',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
   });
 }

--- a/test/datefmt/datefmt_he_IL_test.dart
+++ b/test/datefmt/datefmt_he_IL_test.dart
@@ -1089,5 +1089,20 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtTemplateCalendar_he_IL', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'he-IL', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'he-IL',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
   });
 }

--- a/test/datefmt/datefmt_hi_IN_test.dart
+++ b/test/datefmt/datefmt_hi_IN_test.dart
@@ -1098,5 +1098,27 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtINConstructorEmpty_hi_IN', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(locale: 'hi-IN'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtINTemplateCalendar_hi_IN', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'hi-IN',
+          calendar: 'julian',
+          template: 'yyyy-MM-dd',
+          timezone: 'local'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'hi-IN',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
   });
 }

--- a/test/datefmt/datefmt_hr_HR_test.dart
+++ b/test/datefmt/datefmt_hr_HR_test.dart
@@ -963,5 +963,24 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtConstructorEmpty_hr_HR', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(locale: 'hr-HR'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtTemplateCalendar_hr_HR', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'hr-HR', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'hr-HR',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
   });
 }

--- a/test/datefmt/datefmt_id_ID_test.dart
+++ b/test/datefmt/datefmt_id_ID_test.dart
@@ -1089,5 +1089,39 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtConstructorEmpty_id_ID', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(locale: 'id-ID'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtTemplateCalendar_id_ID', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'id-ID', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'id-ID',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
+    test('testDateFmtTemplateCalendarIncompatibleDateType_id_ID', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'id-ID', calendar: 'julian', template: 'yyyy-MM-dd HH:mm'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'id-ID',
+          calendar: 'gregorian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-16 13:45');
+    });
   });
 }

--- a/test/datefmt/datefmt_it_IT_test.dart
+++ b/test/datefmt/datefmt_it_IT_test.dart
@@ -1082,5 +1082,39 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13.45');
     });
+    test('testDateFmtConstructorEmpty_it_IT', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(locale: 'it-IT'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtTemplateCalendar_it_IT', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'it-IT', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'it-IT',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
+    test('testDateFmtTemplateCalendarIncompatibleDateType_it_IT', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'it-IT', calendar: 'julian', template: 'yyyy-MM-dd HH:mm'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'it-IT',
+          calendar: 'gregorian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-16 13:45');
+    });
   });
 }

--- a/test/datefmt/datefmt_ja_JP_test.dart
+++ b/test/datefmt/datefmt_ja_JP_test.dart
@@ -1079,5 +1079,39 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtConstructorEmpty_ja_JP', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(locale: 'ja-JP'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtTemplateCalendar_ja_JP', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'ja-JP', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'ja-JP',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
+    test('testDateFmtTemplateCalendarIncompatibleDateType_ja_JP', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'ja-JP', calendar: 'julian', template: 'yyyy-MM-dd HH:mm'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'ja-JP',
+          calendar: 'gregorian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-16 13:45');
+    });
   });
 }

--- a/test/datefmt/datefmt_ka_GE_test.dart
+++ b/test/datefmt/datefmt_ka_GE_test.dart
@@ -1104,5 +1104,39 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtConstructorEmpty_ka_GE', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(locale: 'ka-GE'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtTemplateCalendar_ka_GE', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'ka-GE', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'ka-GE',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
+    test('testDateFmtTemplateCalendarIncompatibleDateType_ka_GE', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'ka-GE', calendar: 'julian', template: 'yyyy-MM-dd HH:mm'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'ka-GE',
+          calendar: 'gregorian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-16 13:45');
+    });
   });
 }

--- a/test/datefmt/datefmt_kk_Cyrl_KZ_test.dart
+++ b/test/datefmt/datefmt_kk_Cyrl_KZ_test.dart
@@ -967,5 +967,25 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtConstructorEmpty_kk_Cyrl_KZ', () {
+      final ILibDateFmt fmt =
+          ILibDateFmt(ILibDateFmtOptions(locale: 'kk-Cyrl-KZ'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtTemplateCalendar_kk_Cyrl_KZ', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'kk-Cyrl-KZ', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'kk-Cyrl-KZ',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
   });
 }

--- a/test/datefmt/datefmt_km_KH_test.dart
+++ b/test/datefmt/datefmt_km_KH_test.dart
@@ -1060,5 +1060,24 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtConstructorEmpty_km_KH', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(locale: 'km-KH'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtTemplateCalendar_km_KH', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'km-KH', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'km-KH',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
   });
 }

--- a/test/datefmt/datefmt_kn_IN_test.dart
+++ b/test/datefmt/datefmt_kn_IN_test.dart
@@ -1052,5 +1052,24 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtINConstructorEmpty_kn_IN', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(locale: 'kn-IN'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtINTemplateCalendar_kn_IN', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'kn-IN', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'kn-IN',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
   });
 }

--- a/test/datefmt/datefmt_ko_KR_test.dart
+++ b/test/datefmt/datefmt_ko_KR_test.dart
@@ -1095,5 +1095,39 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtConstructorEmpty_ko_KR', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(locale: 'ko-KR'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtTemplateCalendar_ko_KR', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'ko-KR', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'ko-KR',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
+    test('testDateFmtTemplateCalendarIncompatibleDateType_ko_KR', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'ko-KR', calendar: 'julian', template: 'yyyy-MM-dd HH:mm'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'ko-KR',
+          calendar: 'gregorian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-16 13:45');
+    });
   });
 }

--- a/test/datefmt/datefmt_ku_Arab_IQ_test.dart
+++ b/test/datefmt/datefmt_ku_Arab_IQ_test.dart
@@ -1308,5 +1308,20 @@ void main() {
         expect(fmt.format(dateOptions), '13:45');
       }
     });
+    test('testDateFmtTemplateCalendar_ku_Arab_IQ', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'ku-Arab-IQ', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'ku-Arab-IQ',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
   });
 }

--- a/test/datefmt/datefmt_lt_LT_test.dart
+++ b/test/datefmt/datefmt_lt_LT_test.dart
@@ -1021,5 +1021,24 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtConstructorEmpty_lt_LT', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(locale: 'lt-LT'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtTemplateCalendar_lt_LT', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'lt-LT', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'lt-LT',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
   });
 }

--- a/test/datefmt/datefmt_lv_LV_test.dart
+++ b/test/datefmt/datefmt_lv_LV_test.dart
@@ -1011,5 +1011,24 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtConstructorEmpty_lv_LV', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(locale: 'lv-LV'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtTemplateCalendar_lv_LV', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'lv-LV', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'lv-LV',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
   });
 }

--- a/test/datefmt/datefmt_mk_MK_test.dart
+++ b/test/datefmt/datefmt_mk_MK_test.dart
@@ -963,5 +963,24 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtConstructorEmpty_mk_MK', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(locale: 'mk-MK'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtTemplateCalendar_mk_MK', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'mk-MK', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'mk-MK',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
   });
 }

--- a/test/datefmt/datefmt_ml_IN_test.dart
+++ b/test/datefmt/datefmt_ml_IN_test.dart
@@ -596,5 +596,24 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtINConstructorEmpty_ml_IN', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(locale: 'ml-IN'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtINTemplateCalendar_ml_IN', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'ml-IN', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'ml-IN',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
   });
 }

--- a/test/datefmt/datefmt_mn_Cyrl_MN_test.dart
+++ b/test/datefmt/datefmt_mn_Cyrl_MN_test.dart
@@ -1096,5 +1096,42 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtConstructorEmpty_mn_Cyrl_MN', () {
+      final ILibDateFmt fmt =
+          ILibDateFmt(ILibDateFmtOptions(locale: 'mn-Cyrl-MN'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtTemplateCalendar_mn_Cyrl_MN', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'mn-Cyrl-MN', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'mn-Cyrl-MN',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
+    test('testDateFmtTemplateCalendarIncompatibleDateType_mn_Cyrl_MN', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'mn-Cyrl-MN',
+          calendar: 'julian',
+          template: 'yyyy-MM-dd HH:mm'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'mn-Cyrl-MN',
+          calendar: 'gregorian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-16 13:45');
+    });
   });
 }

--- a/test/datefmt/datefmt_mr_IN_test.dart
+++ b/test/datefmt/datefmt_mr_IN_test.dart
@@ -1051,5 +1051,27 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtINConstructorEmpty_mr_IN', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(locale: 'mr-IN'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtINTemplateCalendar_mr_IN', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'mr-IN',
+          calendar: 'julian',
+          template: 'yyyy-MM-dd',
+          useNative: false));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'mr-IN',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
   });
 }

--- a/test/datefmt/datefmt_ms_MY_test.dart
+++ b/test/datefmt/datefmt_ms_MY_test.dart
@@ -1091,5 +1091,20 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtTemplateCalendar_ms_MY', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'ms-MY', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'ms-MY',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
   });
 }

--- a/test/datefmt/datefmt_nb_NO_test.dart
+++ b/test/datefmt/datefmt_nb_NO_test.dart
@@ -1011,5 +1011,24 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtConstructorEmpty_nb_NO', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(locale: 'nb-NO'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtTemplateCalendar_nb_NO', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'nb-NO', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'nb-NO',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
   });
 }

--- a/test/datefmt/datefmt_nl_NL_test.dart
+++ b/test/datefmt/datefmt_nl_NL_test.dart
@@ -1090,5 +1090,39 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13.45');
     });
+    test('testDateFmtConstructorEmpty_nl_NL', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(locale: 'nl-NL'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtTemplateCalendar_nl_NL', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'nl-NL', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'nl-NL',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
+    test('testDateFmtTemplateCalendarIncompatibleDateType_nl_NL', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'nl-NL', calendar: 'julian', template: 'yyyy-MM-dd HH:mm'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'nl-NL',
+          calendar: 'gregorian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-16 13:45');
+    });
   });
 }

--- a/test/datefmt/datefmt_or_IN_test.dart
+++ b/test/datefmt/datefmt_or_IN_test.dart
@@ -1060,5 +1060,24 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtINConstructorEmpty_or_IN', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(locale: 'or-IN'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtINTemplateCalendar_or_IN', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'or-IN', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'or-IN',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
   });
 }

--- a/test/datefmt/datefmt_pa_IN_test.dart
+++ b/test/datefmt/datefmt_pa_IN_test.dart
@@ -1098,5 +1098,24 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtINConstructorEmpty_pa_IN', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(locale: 'pa-IN'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtINTemplateCalendar_pa_IN', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'pa-IN', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'pa-IN',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
   });
 }

--- a/test/datefmt/datefmt_ro_RO_test.dart
+++ b/test/datefmt/datefmt_ro_RO_test.dart
@@ -1011,5 +1011,24 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtConstructorEmpty_ro_RO', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(locale: 'ro-RO'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtTemplateCalendar_ro_RO', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'ro-RO', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'ro-RO',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
   });
 }

--- a/test/datefmt/datefmt_ru_RU_test.dart
+++ b/test/datefmt/datefmt_ru_RU_test.dart
@@ -1095,5 +1095,39 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtConstructorEmpty_ru_RU', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(locale: 'ru-RU'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtTemplateCalendar_ru_RU', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'ru-RU', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'ru-RU',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
+    test('testDateFmtTemplateCalendarIncompatibleDateType_ru_RU', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'ru-RU', calendar: 'julian', template: 'yyyy-MM-dd HH:mm'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'ru-RU',
+          calendar: 'gregorian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-16 13:45');
+    });
   });
 }

--- a/test/datefmt/datefmt_si_LK_test.dart
+++ b/test/datefmt/datefmt_si_LK_test.dart
@@ -1063,5 +1063,24 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtConstructorEmpty_si_LK', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(locale: 'si-LK'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtTemplateCalendar_si_LK', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'si-LK', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'si-LK',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
   });
 }

--- a/test/datefmt/datefmt_sk_SK_test.dart
+++ b/test/datefmt/datefmt_sk_SK_test.dart
@@ -1059,5 +1059,24 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtConstructorEmpty_sk_SK', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(locale: 'sk-SK'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtTemplateCalendar_sk_SK', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'sk-SK', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'sk-SK',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
   });
 }

--- a/test/datefmt/datefmt_sl_SI_test.dart
+++ b/test/datefmt/datefmt_sl_SI_test.dart
@@ -1141,5 +1141,24 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtConstructorEmpty_sl_SI', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(locale: 'sl-SI'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtTemplateCalendar_sl_SI', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'sl-SI', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'sl-SI',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
   });
 }

--- a/test/datefmt/datefmt_sq_AL_test.dart
+++ b/test/datefmt/datefmt_sq_AL_test.dart
@@ -971,5 +971,24 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtINConstructorEmpty_sq_AL', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(locale: 'sq-AL'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtINTemplateCalendar_sq_AL', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'sq-AL', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'sq-AL',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
   });
 }

--- a/test/datefmt/datefmt_sr_Latn_RS_test.dart
+++ b/test/datefmt/datefmt_sr_Latn_RS_test.dart
@@ -1159,5 +1159,25 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtConstructorEmpty_sr_Latn_RS', () {
+      final ILibDateFmt fmt =
+          ILibDateFmt(ILibDateFmtOptions(locale: 'sr-Latn-RS'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtTemplateCalendar_sr_Latn_RS', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'sr-Latn-RS', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'sr-Latn-RS',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
   });
 }

--- a/test/datefmt/datefmt_sv_SE_test.dart
+++ b/test/datefmt/datefmt_sv_SE_test.dart
@@ -1105,5 +1105,24 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtConstructorEmpty_sv_SE', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(locale: 'sv-SE'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtTemplateCalendar_sv_SE', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'sv-SE', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'sv-SE',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
   });
 }

--- a/test/datefmt/datefmt_sw_KE_test.dart
+++ b/test/datefmt/datefmt_sw_KE_test.dart
@@ -1060,5 +1060,25 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtConstructorEmpty_sw_KE', () {
+      final ILibDateFmt fmt =
+          ILibDateFmt(ILibDateFmtOptions(locale: 'sw-Latn-KE'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtTemplateCalendar_sw_KE', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'sw-Latn-KE', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'sw-Latn-KE',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
   });
 }

--- a/test/datefmt/datefmt_ta_IN_test.dart
+++ b/test/datefmt/datefmt_ta_IN_test.dart
@@ -209,5 +209,24 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtINConstructorEmpty_ta_IN', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(locale: 'ta-IN'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtINTemplateCalendar_ta_IN', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'ta-IN', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'ta-IN',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
   });
 }

--- a/test/datefmt/datefmt_te_IN_test.dart
+++ b/test/datefmt/datefmt_te_IN_test.dart
@@ -1060,5 +1060,24 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtINConstructorEmpty_te_IN', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(locale: 'te-IN'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtINTemplateCalendar_te_IN', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'te-IN', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'te-IN',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
   });
 }

--- a/test/datefmt/datefmt_th_TH_test.dart
+++ b/test/datefmt/datefmt_th_TH_test.dart
@@ -1538,5 +1538,24 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtConstructorEmpty_th_TH', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(locale: 'th-TH'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtTemplateCalendar_th_TH', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'th-TH', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'th-TH',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
   });
 }

--- a/test/datefmt/datefmt_tr_TR_test.dart
+++ b/test/datefmt/datefmt_tr_TR_test.dart
@@ -1011,5 +1011,24 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtConstructorEmpty_tr_TR', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(locale: 'tr-TR'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtTemplateCalendar_tr_TR', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'tr-TR', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'tr-TR',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
   });
 }

--- a/test/datefmt/datefmt_uk_UA_test.dart
+++ b/test/datefmt/datefmt_uk_UA_test.dart
@@ -1011,5 +1011,24 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtConstructorEmpty_uk_UA', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(locale: 'uk-UA'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtTemplateCalendar_uk_UA', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'uk-UA', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'uk-UA',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
   });
 }

--- a/test/datefmt/datefmt_ur_IN_test.dart
+++ b/test/datefmt/datefmt_ur_IN_test.dart
@@ -1051,5 +1051,24 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '۱۳:۴۵');
     });
+    test('testDateFmtINConstructorEmpty_ur_IN', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(locale: 'ur-IN'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtINTemplateCalendar_ur_IN', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'ur-IN', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'ur-IN',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '۲۰۱۱-۰۹-۲۹');
+    });
   });
 }

--- a/test/datefmt/datefmt_uz_Latn_UZ_test.dart
+++ b/test/datefmt/datefmt_uz_Latn_UZ_test.dart
@@ -1014,5 +1014,25 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtConstructorEmpty_uz_Latn_UZ', () {
+      final ILibDateFmt fmt =
+          ILibDateFmt(ILibDateFmtOptions(locale: 'uz-Latn-UZ'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtTemplateCalendar_uz_Latn_UZ', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'uz-Latn-UZ', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'uz-Latn-UZ',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
   });
 }

--- a/test/datefmt/datefmt_vi_VN_test.dart
+++ b/test/datefmt/datefmt_vi_VN_test.dart
@@ -1127,5 +1127,24 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtConstructorEmpty_vi_VN', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(locale: 'vi-VN'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtTemplateCalendar_vi_VN', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'vi-VN', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'vi-VN',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
   });
 }

--- a/test/datefmt/datefmt_zh_CN_test.dart
+++ b/test/datefmt/datefmt_zh_CN_test.dart
@@ -1078,5 +1078,42 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtConstructorEmpty_zh_Hans_CN', () {
+      final ILibDateFmt fmt =
+          ILibDateFmt(ILibDateFmtOptions(locale: 'zh-Hans-CN'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtTemplateCalendar_zh_Hans_CN', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'zh-Hans-CN', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'zh-Hans-CN',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
+    test('testDateFmtTemplateCalendarIncompatibleDateType_zh_Hans_CN', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'zh-Hans-CN',
+          calendar: 'julian',
+          template: 'yyyy-MM-dd HH:mm'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'zh-Hans-CN',
+          calendar: 'gregorian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-16 13:45');
+    });
   });
 }

--- a/test/datefmt/datefmt_zh_Hant_HK_test.dart
+++ b/test/datefmt/datefmt_zh_Hant_HK_test.dart
@@ -1190,5 +1190,42 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtConstructorEmpty_zh_Hant_HK', () {
+      final ILibDateFmt fmt =
+          ILibDateFmt(ILibDateFmtOptions(locale: 'zh-Hant-HK'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtTemplateCalendar_zh_Hant_HK', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'zh-Hant-HK', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'zh-Hant-HK',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
+    test('testDateFmtTemplateCalendarIncompatibleDateType_zh_Hant_HK', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'zh-Hant-HK',
+          calendar: 'julian',
+          template: 'yyyy-MM-dd HH:mm'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'zh-Hant-HK',
+          calendar: 'gregorian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-16 13:45');
+    });
   });
 }

--- a/test/datefmt/datefmt_zh_Hant_TW_test.dart
+++ b/test/datefmt/datefmt_zh_Hant_TW_test.dart
@@ -1263,5 +1263,42 @@ void main() {
           millisecond: 0);
       expect(fmt.format(dateOptions), '13:45');
     });
+    test('testDateFmtConstructorEmpty_zh_Hant_TW', () {
+      final ILibDateFmt fmt =
+          ILibDateFmt(ILibDateFmtOptions(locale: 'zh-Hant-TW'));
+      expect(fmt, isNotNull);
+    });
+    test('testDateFmtTemplateCalendar_zh_Hant_TW', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'zh-Hant-TW', calendar: 'julian', template: 'yyyy-MM-dd'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'zh-Hant-TW',
+          calendar: 'julian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-29');
+    });
+    test('testDateFmtTemplateCalendarIncompatibleDateType_zh_Hant_TW', () {
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+          locale: 'zh-Hant-TW',
+          calendar: 'julian',
+          template: 'yyyy-MM-dd HH:mm'));
+      final ILibDateOptions date = ILibDateOptions(
+          locale: 'zh-Hant-TW',
+          calendar: 'gregorian',
+          year: 2011,
+          month: 9,
+          day: 29,
+          hour: 13,
+          minute: 45,
+          second: 0,
+          millisecond: 0);
+      expect(fmt.format(date), '2011-09-16 13:45');
+    });
   });
 }


### PR DESCRIPTION
### Checklist

The following lists affects Pub Points on pub.dev when the package is published.
* [ ] Passed the all tests.
* [ ] Verified that the example app works.
* [ ] Executed the `dart format` command.
* [ ] Added the API description is added if necessary.

## Summary

Fills in the datefmt `format()` cases missing from the initial pure-Dart
conversion, converted 1:1 from iLib JS `testdatefmt_*.js` (v14.22.0):
`ConstructorEmpty`, `TemplateCalendar`, native/Persian-digit formats,
Simple/Type/DateTime variants, date/time component permutations, template
clock switches, and Islamic/Hebrew calendar cases. Tests only, no prod changes.

## Note

Commented-out JS tests are skipped (they don't run in JS → no verified
expected value): ml_IN/ta_IN time cases inside disabled `/* */` blocks
(stale a.m./p.m. markers) and the duplicate en_US Hebrew case.

## Testing

`flutter test test/datefmt/` → **13,893 pass** ✅
