### PR TITLE
[migration/ilib-js-to-dart] Add pre-commit hook enforcing dart format

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,7 +161,9 @@ lib/
   their tests — those still reference the removed `ILibJS` and report errors until ported).
 - **Formatting — run `dart format`.** The repo is formatted with the **short style at
   `page_width: 80`** (set in `analysis_options.yaml`; short because the package SDK floor is
-  < 3.7). Format-on-save is fine; run `dart format .` before committing. Switching to the modern
+  < 3.7). Format-on-save is fine; run `dart format .` before committing — a committed pre-commit
+  hook enforces this (install once with `scripts/install-git-hooks.sh`; see
+  [docs/development.md](docs/development.md) › Code Style & Formatting). Switching to the modern
   "tall" style would require raising the SDK floor to ≥ 3.7 and a one-time repo-wide reformat in
   its own commit.
 - Explicit type declarations (`always_specify_types`)

--- a/benchmark/lib/benchmark.dart
+++ b/benchmark/lib/benchmark.dart
@@ -147,13 +147,17 @@ class _BenchmarkAppState extends State<BenchmarkApp> {
     final ILibDateOptions date = ILibDateOptions(dateTime: DateTime.now());
     int li = 0;
     final List<ILibDateFmt> fmts = _locales
-        .map((String lo) => ILibDateFmt(ILibDateFmtOptions(
+        .map(
+          (String lo) => ILibDateFmt(
+            ILibDateFmtOptions(
               locale: lo,
               length: 'full',
               type: 'datetime',
               useNative: false,
               timezone: 'local',
-            )))
+            ),
+          ),
+        )
         .toList();
     final double formatUs = _perOp(_formatIters, () {
       fmts[li++ % fmts.length].format(date);
@@ -164,13 +168,15 @@ class _BenchmarkAppState extends State<BenchmarkApp> {
     int ci = 0;
     final double constructUs = _perOp(_constructIters, () {
       final String lo = _locales[ci++ % _locales.length];
-      ILibDateFmt(ILibDateFmtOptions(
-        locale: lo,
-        length: 'full',
-        type: 'datetime',
-        useNative: false,
-        timezone: 'local',
-      )).format(date);
+      ILibDateFmt(
+        ILibDateFmtOptions(
+          locale: lo,
+          length: 'full',
+          type: 'datetime',
+          useNative: false,
+          timezone: 'local',
+        ),
+      ).format(date);
     });
     row('construct + format()', '${constructUs.toStringAsFixed(3)} µs/op');
 
@@ -219,10 +225,7 @@ class _BenchmarkAppState extends State<BenchmarkApp> {
           child: SingleChildScrollView(
             child: Text(
               _report,
-              style: const TextStyle(
-                fontFamily: 'monospace',
-                fontSize: 22,
-              ),
+              style: const TextStyle(fontFamily: 'monospace', fontSize: 22),
             ),
           ),
         ),

--- a/docs/development.md
+++ b/docs/development.md
@@ -75,6 +75,23 @@ After this, `scripts/git-hooks/pre-commit` runs `dart format --output=none
 file is not formatted, printing how to fix it. To bypass once: `git commit --no-verify`. To disable:
 `git config --unset core.hooksPath`.
 
+#### Troubleshooting: `dart format` gives a different result
+
+If a file reformats differently on two runs (short style vs. the "tall" style that splits every
+parameter and **adds trailing commas**), it is **not** a Dart/Flutter version difference. The style
+comes from the file's resolved **language version**: `< 3.7` → short, `≥ 3.7` → tall. Check
+`.dart_tool/package_config.json` — this package's `languageVersion` should be `3.1` (derived from the
+`pubspec.yaml` SDK floor):
+
+```bash
+grep -A2 '"flutter_ilib"' .dart_tool/package_config.json   # expect "languageVersion": "3.1"
+```
+
+A tall result means the package default was overridden: the file was formatted **outside the package**
+(no pubspec → SDK latest), or a `--language-version` flag / `// @dart=` comment forced it. Fix: always
+run `dart format .` from the repo root. Never commit `package_config.json` — it is a `.gitignore`d
+cache regenerated from `pubspec.yaml` by `pub get`.
+
 ### Static Analysis
 
 ```bash

--- a/docs/development.md
+++ b/docs/development.md
@@ -62,6 +62,19 @@ dart format --output=none --set-exit-if-changed .
 Switching to the modern "tall" style would mean raising the SDK floor to ≥ 3.7 and doing a one-time
 repo-wide reformat in its own commit. See CLAUDE.md › Conventions › Code Style.
 
+#### Enforce it with the pre-commit hook
+
+To guarantee formatting is never forgotten, install the committed git hook once per clone:
+
+```bash
+scripts/install-git-hooks.sh   # sets core.hooksPath -> scripts/git-hooks
+```
+
+After this, `scripts/git-hooks/pre-commit` runs `dart format --output=none
+--set-exit-if-changed` on the staged `.dart` files at every commit and **aborts the commit** if any
+file is not formatted, printing how to fix it. To bypass once: `git commit --no-verify`. To disable:
+`git config --unset core.hooksPath`.
+
 ### Static Analysis
 
 ```bash
@@ -391,8 +404,12 @@ List<String> getJSONDataPaths(String? locale) {
 
 ### Before Committing
 
+> One-time setup: `scripts/install-git-hooks.sh` installs a pre-commit hook that runs the
+> `dart format` check automatically (step 1 below) and blocks the commit if anything is unformatted.
+> See Code Style & Formatting › *Enforce it with the pre-commit hook*.
+
 ```bash
-# 1. Format
+# 1. Format  (also enforced by the pre-commit hook once installed)
 dart format .
 
 # 2. Run analysis

--- a/example/integration_test/example_app_integration_test.dart
+++ b/example/integration_test/example_app_integration_test.dart
@@ -75,7 +75,8 @@ void main() {
   };
 
   group('Real usage locale flow integration tests', () {
-    testWidgets('Single app session should pass through all locales in sequence',
+    testWidgets(
+        'Single app session should pass through all locales in sequence',
         (WidgetTester tester) async {
       await tester.pumpWidget(const MyApp());
       await _waitForInit(tester);
@@ -186,8 +187,7 @@ Future<void> _tapWithVisualDelay(WidgetTester tester, Finder button,
 }
 
 Future<void> _waitForInit(WidgetTester tester) async {
-  await _waitUntil(
-      tester, 'iLib Version', (value) => value != 'Unknown iLib');
+  await _waitUntil(tester, 'iLib Version', (value) => value != 'Unknown iLib');
 }
 
 Future<void> _waitForLabelToEqual(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -81,7 +81,8 @@ class _MyAppState extends State<MyApp> {
     }
 
     final now = DateTime.now();
-    currentTime = '${now.year}-${now.month.toString().padLeft(2, '0')}-${now.day.toString().padLeft(2, '0')} ${now.hour.toString().padLeft(2, '0')}:${now.minute.toString().padLeft(2, '0')}';
+    currentTime =
+        '${now.year}-${now.month.toString().padLeft(2, '0')}-${now.day.toString().padLeft(2, '0')} ${now.hour.toString().padLeft(2, '0')}:${now.minute.toString().padLeft(2, '0')}';
 
     results[0] = getDateTimeFormatFixed(curLocale);
     results[1] = getFirstDayOfWeek(curLocale);

--- a/lib/internal/math_utils.dart
+++ b/lib/internal/math_utils.dart
@@ -20,10 +20,12 @@ double roundFloor(double number) => number.floorToDouble();
 double roundCeiling(double number) => number.ceilToDouble();
 
 /// Round toward zero (truncate).
-double roundDown(double number) => number < 0 ? number.ceilToDouble() : number.floorToDouble();
+double roundDown(double number) =>
+    number < 0 ? number.ceilToDouble() : number.floorToDouble();
 
 /// Round away from zero.
-double roundUp(double number) => number < 0 ? number.floorToDouble() : number.ceilToDouble();
+double roundUp(double number) =>
+    number < 0 ? number.floorToDouble() : number.ceilToDouble();
 
 /// Round half up (ties go away from zero).
 double roundHalfup(double number) =>
@@ -34,16 +36,19 @@ double roundHalfdown(double number) =>
     number < 0 ? (number + 0.5).floorToDouble() : (number - 0.5).ceilToDouble();
 
 /// Round half even (banker's rounding — ties go to nearest even).
-double roundHalfeven(double number) =>
-    (number.floorToDouble() % 2 == 0) ? (number - 0.5).ceilToDouble() : (number + 0.5).floorToDouble();
+double roundHalfeven(double number) => (number.floorToDouble() % 2 == 0)
+    ? (number - 0.5).ceilToDouble()
+    : (number + 0.5).floorToDouble();
 
 /// Round half odd (ties go to nearest odd).
-double roundHalfodd(double number) =>
-    (number.floorToDouble() % 2 != 0) ? (number - 0.5).ceilToDouble() : (number + 0.5).floorToDouble();
+double roundHalfodd(double number) => (number.floorToDouble() % 2 != 0)
+    ? (number - 0.5).ceilToDouble()
+    : (number + 0.5).floorToDouble();
 
 /// Round half toward positive infinity (mirrors JS Math.round behavior).
 /// For positive numbers: ties go up. For negative numbers: ties go toward zero.
-double roundHalfPositiveInfinity(double number) => (number + 0.5).floorToDouble();
+double roundHalfPositiveInfinity(double number) =>
+    (number + 0.5).floorToDouble();
 
 /// Look up a rounding function by mode name, or null if the name is not a
 /// known mode. Mirrors JS `MathUtils[mode]`, which yields undefined for an

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# flutter_ilib pre-commit hook — enforce `dart format` before a commit.
+#
+# The repo is formatted with the short style at page_width: 80 (analysis_options.yaml).
+# This hook checks that every staged .dart file is already formatted; if any file
+# would be reformatted, the commit is aborted with instructions.
+#
+# Install: scripts/install-git-hooks.sh   (sets core.hooksPath to scripts/git-hooks)
+
+set -euo pipefail
+
+# Collect staged Dart files (Added/Copied/Modified/Renamed), NUL-separated for safe paths.
+mapfile -d '' -t staged < <(
+  git diff --cached --name-only --diff-filter=ACMR -z -- '*.dart'
+)
+
+if [ ${#staged[@]} -eq 0 ]; then
+  exit 0
+fi
+
+# `dart format --set-exit-if-changed` exits non-zero if any file needs reformatting.
+# `--output=none` means it only checks; it does not modify files.
+if ! dart format --output=none --set-exit-if-changed "${staged[@]}"; then
+  echo
+  echo "✖ Commit aborted: the staged Dart files above are not formatted."
+  echo "  Run the formatter, then re-stage and commit:"
+  echo
+  echo "      dart format ."
+  echo "      git add -u"
+  echo
+  echo "  (short style, page_width: 80 — see docs/development.md › Code Style & Formatting)"
+  exit 1
+fi

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+# Install the repo's git hooks by pointing core.hooksPath at scripts/git-hooks.
+# Because the hooks live under version control, every contributor gets the same
+# checks after running this once. Run from anywhere inside the repo.
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+git -C "$repo_root" config core.hooksPath scripts/git-hooks
+chmod +x "$repo_root"/scripts/git-hooks/*
+
+echo "Installed git hooks (core.hooksPath -> scripts/git-hooks):"
+ls -1 "$repo_root"/scripts/git-hooks
+echo
+echo "Pre-commit will now run 'dart format' checks on staged .dart files."
+echo "To disable: git config --unset core.hooksPath"

--- a/test/currency/currency_extra_test.dart
+++ b/test/currency/currency_extra_test.dart
@@ -17,8 +17,7 @@ void main() {
 
   group('ILibCurrency extra', () {
     test('getAvailableCurrencies returns the bundled ISO 4217 codes', () {
-      final List<String> currencies =
-          ILibCurrency.getAvailableCurrencies();
+      final List<String> currencies = ILibCurrency.getAvailableCurrencies();
 
       expect(currencies, isNotEmpty);
       // Common currencies that must be present in the bundled data.

--- a/test/datefmt/datefmt_datetime_calendar_extra_test.dart
+++ b/test/datefmt/datefmt_datetime_calendar_extra_test.dart
@@ -35,7 +35,8 @@ void main() {
     // Label only — 'unset' means the `timezone` argument was not passed (null)
     final String tzLabel = timezone ?? 'unset';
     expect(out, contains(expectYear), reason: '$locale tz=$tzLabel → "$out"');
-    expect(out, isNot(contains('2026')), reason: '$locale tz=$tzLabel → "$out"');
+    expect(out, isNot(contains('2026')),
+        reason: '$locale tz=$tzLabel → "$out"');
   }
 
   // Exact full-date check. With the timezone omitted, the formatter uses the

--- a/test/numfmt/numfmt_test.dart
+++ b/test/numfmt/numfmt_test.dart
@@ -4192,6 +4192,5 @@ void main() {
       expect(fmt, isNotNull);
       expect(fmt.format(12345678900), '1.23E+10');
     });
-
   });
 }


### PR DESCRIPTION
### Checklist

The following lists affects Pub Points on pub.dev when the package is published.
* [ ] Passed the all tests.
* [ ] Verified that the example app works.
* [ ] Executed the `dart format` command.
* [ ] Added the API description is added if necessary.

### Summary
Nothing enforced the repo's formatting rule (short style, `page_width: 80`), so unformatted commits could slip through. This adds a committed git hook that blocks a commit when staged `.dart` files aren't formatted.

### Changes
- **`scripts/git-hooks/pre-commit`** — checks staged `.dart` files with `dart format --set-exit-if-changed`; aborts with fix instructions if unformatted.
- **`scripts/install-git-hooks.sh`** — one-time setup (`core.hooksPath → scripts/git-hooks`).
- **`docs/development.md`, `CLAUDE.md`** — document the hook and install step.

### Usage
`.git/hooks` isn't version-controlled, so the hook lives in `scripts/git-hooks/`. Install once per clone:

```bash
scripts/install-git-hooks.sh
```

Then every commit checks staged `.dart` files (only `.dart` — other files pass through). Bypass with `--no-verify`.

### Testing
Verified: unformatted file → commit aborted (exit 1); after `dart format` → passes.