### PR TITLE
[migration/ilib-js-to-dart] feat(scriptinfo): port ILibScriptInfo to pure Dart

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,7 @@ Options → ILibLocaleInfo (determines locale, calendar, clock, meridiems)
 | ILibDateOptions | `lib/ilib_date.dart` | `_toCalendarDate()` delegates per calendar |
 | ILibCurrency | `lib/ilib_currency.dart` | Currency metadata lookup (`ilib.data.currency`) |
 | ILibNumFmt | `lib/ilib_numfmt.dart` | `ilib.data.localeinfo.numfmt` + `ilib.data.currency` |
+| ILibScriptInfo | `lib/ilib_scriptinfo.dart` | `ilib.data.scripts` (root-only, locale-independent) |
 
 ### Not yet ported (currently non-functional)
 The `ILibJS` interop bridge was removed in v2.0, but these classes were never converted to pure
@@ -62,7 +63,6 @@ not compile and are not exported** from `flutter_ilib.dart`. Porting them is the
 | Class | File | `evaluate()` calls to port |
 |-------|------|----------------------------|
 | ILibCountry | `lib/ilib_country.dart` | 5 |
-| ILibScriptInfo | `lib/ilib_scriptinfo.dart` | 7 |
 | ILibDurationFmt | `lib/ilib_durationfmt.dart` | 4 |
 
 ## Conversion Pattern (How to Convert a Class)
@@ -126,7 +126,7 @@ lib/
 ├── ilib_country.dart           # [unconverted] country info
 ├── ilib_durationfmt.dart       # [unconverted] duration format
 ├── ilib_numfmt.dart            # number format
-├── ilib_scriptinfo.dart        # [unconverted] script info
+├── ilib_scriptinfo.dart        # script info (ilib.data.scripts)
 ├── calendar/
 │   ├── rata_die.dart           # ILibRataDie abstract base (shared static methods)
 │   ├── ilib_date.dart          # ILibCalendarDate abstract base
@@ -157,8 +157,9 @@ lib/
 > (+ `calendar-conversion.md`, `local-timezone-support.md`) **before** changing it.
 
 ### Code Style
-- `flutter analyze` must pass for the converted code (`lib/` minus the 4 unported classes and
-  their tests — those still reference the removed `ILibJS` and report errors until ported).
+- `flutter analyze` must pass for the converted code (`lib/` minus the 2 unported classes —
+  `ILibCountry`, `ILibDurationFmt` — and their tests, which still reference the removed `ILibJS`
+  and report errors until ported).
 - **Formatting — run `dart format`.** The repo is formatted with the **short style at
   `page_width: 80`** (set in `analysis_options.yaml`; short because the package SDK floor is
   < 3.7). Format-on-save is fine; run `dart format .` before committing. Switching to the modern
@@ -219,9 +220,8 @@ For in-depth explanations, see `docs/`:
   Strategy B (`flutter_timezone`) is only needed if `getId()` must return the real zone name
   (e.g. `Asia/Seoul`) instead of `'local'`. See
   [docs/local-timezone-support.md](docs/local-timezone-support.md).
-- The 4 unported classes (`ILibCountry`, `ILibScriptInfo`, `ILibDurationFmt`, `ILibNumFmt`) — they
-  still call the now-removed `ILibJS`, so they don't compile / aren't exported; see Conversion
-  Status.
+- The 2 unported classes (`ILibCountry`, `ILibDurationFmt`) — they still call the now-removed
+  `ILibJS`, so they don't compile / aren't exported; see Conversion Status.
 
 ## Running Tests
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,10 @@ lib/
   **Do not decide by "the value happens to reproduce":** an unsupported locale can still yield the
   JS value by language fallback, yet it is out of scope — only convert the variant that is in
   `locales.json`. See [docs/conversion-guide.md](docs/conversion-guide.md) › Test Conversion.
+- **Script-explicit 3-part locale** (e.g. `pa-Guru-IN`): in scope if its 2-part form (`pa-IN`)
+  is in `locales.json` — same asset files, identical data. N/A if neither form is bundled.
+- **Language-only locale** (e.g. `az`, `pa`): in scope if at least one `{lang}-*` locale is in
+  `locales.json` (meaning `{lang}.json` exists). N/A if no `{lang}-*` is bundled (e.g. `ig`, `lb`).
 
 ### Public API Export
 - All public classes exported from `lib/flutter_ilib.dart`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,8 +22,7 @@ flutter_ilib (Dart/Flutter Plugin)
     │   ├── ILibCalendar (+ lib/calendar/: 9 calendars, Rata Die, Astro)
     │   ├── ILibTimeZone
     │   └── ILibLoader (data loading)
-    │   (still on JS interop, not yet ported: ILibCountry, ILibScriptInfo,
-    │    ILibNumFmt, ILibDurationFmt)
+    │   (still on JS interop, not yet ported: ILibCountry, ILibDurationFmt)
     │
     ├── Internal (lib/internal/)
     │   ├── ilib_utils.dart (locale path generation, validation)

--- a/docs/conversion-guide.md
+++ b/docs/conversion-guide.md
@@ -23,14 +23,14 @@ Guide for converting flutter_ilib's JavaScript interop dependencies to pure Dart
 | `ILibCalendar` | `lib/ilib_calendar.dart` + `lib/calendar/` | Calendar factory + all calendar types |
 | `ILibCurrency` | `lib/ilib_currency.dart` | Currency metadata lookup and resolution |
 | `ILibNumFmt` | `lib/ilib_numfmt.dart` | Pure Dart number/currency formatting |
+| `ILibScriptInfo` | `lib/ilib_scriptinfo.dart` | `ilib.data.scripts` lookup (root-only, locale-independent) |
 
 ### Remaining
 
 | Class | File | JS Calls | Suggested Priority |
 |-------|------|----------|-------------------|
 | `ILibCountry` | `lib/ilib_country.dart` | 5 | 1st — simple structure |
-| `ILibScriptInfo` | `lib/ilib_scriptinfo.dart` | 7 | 2nd — simple structure |
-| `ILibDurationFmt` | `lib/ilib_durationfmt.dart` | 5 | 3rd |
+| `ILibDurationFmt` | `lib/ilib_durationfmt.dart` | 5 | 2nd |
 
 ## Conversion Pattern
 

--- a/docs/conversion-guide.md
+++ b/docs/conversion-guide.md
@@ -85,6 +85,8 @@ String getClock() {
 - [ ] **Do NOT convert JS tests for a locale that flutter_ilib does not support.** The authoritative list of supported locales is `scripts/assemble_ilib/locales.json` (the seed used to generate `assets/locale/`) — a per-locale test is in scope only if its locale is in that list.
   - When the data is fully absent, `ILibLocaleInfo`/`ILibTimeZone.fromLocale` fall back to defaults (e.g. `Etc/UTC`) and the JS expected value (e.g. `Asia/Ashgabat`) cannot be reproduced — N/A (e.g. `testTZGetDefaultFor_tk_TM`/`_tg_TJ`/`_wo_SN`/`_zu_ZA`/`_mt_MT`).
   - **Do not rely on "the value happens to reproduce" to decide.** An unsupported locale can still produce the JS value by language fallback (e.g. `ku-IQ` resolves via `ku` + `und-IQ`), yet it is out of scope because it is not in `locales.json`. Conversely, only convert the supported variant (e.g. `ku-Arab-IQ` **is** in the list; `ku-IQ`/`ku-TR` are not). Membership in `locales.json` — not data presence or accidental fallback — is the test.
+  - **Script-explicit 3-part locales** (e.g. `pa-Guru-IN`) whose 2-part form (`pa-IN`) is in `locales.json` are also in scope — port the JS test as-is. `pa-Guru-IN` is the BCP-47 form with an explicit script tag; it loads the same asset files as `pa-IN` and produces identical data. If neither 3-part nor 2-part is in `locales.json`, the test is N/A.
+  - **Language-only locales** (e.g. `az`, `pa`) are in scope when at least one `{lang}-*` locale is in `locales.json` (meaning `{lang}.json` exists). If no `{lang}-*` locale is bundled, the language-only test is N/A (e.g. `ig`, `lb`).
 - [ ] Dart-specific additional tests (getDayOfYear, getEra, etc.) go in a separate `*_extra_test.dart` file
 
 ### 5. Cleanup
@@ -92,6 +94,17 @@ String getClock() {
 - [ ] Verify exports in `flutter_ilib.dart`
 - [ ] Run existing tests to confirm identical results
 - [ ] Remove JS interop imports (`flutter_js`, `dart:ffi`, etc.)
+
+## Intentional API Differences from JS
+
+Some JS APIs accept optional or loosely-typed arguments that Dart's type system
+cannot express the same way. These differences are intentional — they make the
+Dart API clearer without changing observable behaviour.
+
+| Class | JS API | Dart API | Reason |
+|-------|--------|----------|--------|
+| `ILibScriptInfo` | `new ScriptInfo()` — `script` is optional; omitting it yields an instance where all getters return defaults | `ILibScriptInfo(String script)` — `script` is required; pass `''` to replicate the JS no-arg behaviour | Dart requires explicit types; a no-arg constructor with no useful state is misleading |
+| `ILibNumFmt` | `constrain(number)` — accepts any JS number, returns `number` | `double constrain(num number)` — `num` accepts both `int` and `double`, returns `double` | JS has a single `number` type; Dart distinguishes `int`/`double` — `num` is the correct abstract supertype |
 
 ## Core Infrastructure
 

--- a/docs/test-mapping.md
+++ b/docs/test-mapping.md
@@ -207,6 +207,37 @@ These tests have no JS counterpart. They verify the Flutter plugin initializatio
 | `test/numfmt/numfmt_am_test.dart` | `js/test/number/testnumfmt_am.js` | ILibNumFmt am (Amharic) locale formatting |
 | `test/numfmt/numfmt_extra_test.dart` | — | flutter_ilib-specific (no JS counterpart): unknown `roundingMode` falls back to `halfdown` for both the reported mode and the applied rounding, and a valid mode is preserved |
 
+## ScriptInfo Tests
+
+| Dart Test File | iLib JS Source File | Notes |
+|---|---|---|
+| `test/scriptinfo/scriptinfo_test.dart` | `js/test/root/testscriptinfo.js` | ILibScriptInfo (getCode/getCodeNumber/getName/getLongCode/getScriptDirection/getNeedsIME/getCasing + static getAllScripts) — script metadata read from `ilib.data.scripts` (root-only, locale-independent). Converts the 19 script-code/construction cases, every per-locale case whose locale is in `locales.json`, and the bare-language cases for supported languages (`pa`, `ha`, `az`); the per-locale cases for the 86 non-member region/script locales listed below are not converted. |
+
+### Not Converted — ScriptInfo Tests
+
+Per the rule in CLAUDE.md › Conventions › Testing and `docs/conversion-guide.md` step 4
+(**membership in `scripts/assemble_ilib/locales.json` is the test — not data presence or accidental
+fallback**), the 86 `testScriptInfo_<locale>` cases whose locale carries a region/script subtag and
+is **not** in `locales.json` are not converted, and are removed from the test file **even when they
+would pass by language fallback** (e.g. `ar-BH` → `ar` → Arab/rtl, or `mt-MT` → Latn). This mirrors
+the JS source's per-locale cases that exercise an unsupported locale.
+
+**Bare-language exception (kept):** a test whose argument is a bare language code with **no region
+or script subtag** is kept when that language is itself supported — i.e. a bundled `{lang}.json`
+backs the result (`pa` → Guru, `ha` → Latn, `az` → Latn). These exercise real language-level data,
+not an accidental root-default fallback, so they are in scope even though the bare code is not a
+`locales.json` entry. A bare language with **no** bundled data (`ig` — no `ig.json`, not the base of
+any member locale) is *not* kept: it only passes because `getScript()` defaults to `Latn`, exactly
+the accidental-fallback case the rule excludes.
+
+The removed locales (86): `ar-BH ar-DJ ar-DZ ar-JO ar-KW ar-LB ar-LY ar-MR ar-OM ar-QA ar-SD
+ar-SY ar-TN ar-YE az-AZ be-BY ca-AD ca-ES ckb-IQ en-ET en-GM en-KR en-LR en-PK en-RW en-SD
+en-SL en-TZ es-CR es-GQ es-PH eu-ES fa-AF fr-BF fr-BJ fr-CD fr-CF fr-CG fr-CI fr-CM fr-DJ fr-DZ
+fr-GA fr-GN fr-GQ fr-LB fr-ML fr-RW fr-SN fr-TG gl-ES ha-CM ha-NG ha-SD hr-HU hy-AM ig ig-NG
+kk-KZ ku-IQ ky-KG lb-LU lo-LA mn-MN ms-SG mt-MT my-MM ne-NP pa-Arab-PK pa-Guru-IN pa-PK ps-AF
+ps-PK pt-AO pt-CV pt-GQ sr-Cyrl-RS tg-TJ tk-TM ur-PK wo-SN yo-BJ yo-NG zh-Hans-MY zh-Hans-SG
+zu-ZA`.
+
 
 ## Common Not Converted Pattern (All Calendar Date Tests)
 

--- a/docs/test-mapping.md
+++ b/docs/test-mapping.md
@@ -211,32 +211,12 @@ These tests have no JS counterpart. They verify the Flutter plugin initializatio
 
 | Dart Test File | iLib JS Source File | Notes |
 |---|---|---|
-| `test/scriptinfo/scriptinfo_test.dart` | `js/test/root/testscriptinfo.js` | ILibScriptInfo (getCode/getCodeNumber/getName/getLongCode/getScriptDirection/getNeedsIME/getCasing + static getAllScripts) — script metadata read from `ilib.data.scripts` (root-only, locale-independent). Converts the 19 script-code/construction cases, every per-locale case whose locale is in `locales.json`, and the bare-language cases for supported languages (`pa`, `ha`, `az`); the per-locale cases for the 86 non-member region/script locales listed below are not converted. |
+| `test/scriptinfo/scriptinfo_test.dart` | `js/test/root/testscriptinfo.js` | 161 tests converted: script-code/construction cases, per-locale cases in `locales.json`, and bare-language cases for supported languages (`pa`, `ha`, `az`). 85 per-locale cases skipped (N/A). |
 
 ### Not Converted — ScriptInfo Tests
 
-Per the rule in CLAUDE.md › Conventions › Testing and `docs/conversion-guide.md` step 4
-(**membership in `scripts/assemble_ilib/locales.json` is the test — not data presence or accidental
-fallback**), the 86 `testScriptInfo_<locale>` cases whose locale carries a region/script subtag and
-is **not** in `locales.json` are not converted, and are removed from the test file **even when they
-would pass by language fallback** (e.g. `ar-BH` → `ar` → Arab/rtl, or `mt-MT` → Latn). This mirrors
-the JS source's per-locale cases that exercise an unsupported locale.
-
-**Bare-language exception (kept):** a test whose argument is a bare language code with **no region
-or script subtag** is kept when that language is itself supported — i.e. a bundled `{lang}.json`
-backs the result (`pa` → Guru, `ha` → Latn, `az` → Latn). These exercise real language-level data,
-not an accidental root-default fallback, so they are in scope even though the bare code is not a
-`locales.json` entry. A bare language with **no** bundled data (`ig` — no `ig.json`, not the base of
-any member locale) is *not* kept: it only passes because `getScript()` defaults to `Latn`, exactly
-the accidental-fallback case the rule excludes.
-
-The removed locales (86): `ar-BH ar-DJ ar-DZ ar-JO ar-KW ar-LB ar-LY ar-MR ar-OM ar-QA ar-SD
-ar-SY ar-TN ar-YE az-AZ be-BY ca-AD ca-ES ckb-IQ en-ET en-GM en-KR en-LR en-PK en-RW en-SD
-en-SL en-TZ es-CR es-GQ es-PH eu-ES fa-AF fr-BF fr-BJ fr-CD fr-CF fr-CG fr-CI fr-CM fr-DJ fr-DZ
-fr-GA fr-GN fr-GQ fr-LB fr-ML fr-RW fr-SN fr-TG gl-ES ha-CM ha-NG ha-SD hr-HU hy-AM ig ig-NG
-kk-KZ ku-IQ ky-KG lb-LU lo-LA mn-MN ms-SG mt-MT my-MM ne-NP pa-Arab-PK pa-Guru-IN pa-PK ps-AF
-ps-PK pt-AO pt-CV pt-GQ sr-Cyrl-RS tg-TJ tk-TM ur-PK wo-SN yo-BJ yo-NG zh-Hans-MY zh-Hans-SG
-zu-ZA`.
+85 `testScriptInfo_<locale>` cases skipped — locale not in `locales.json`, or bare-language with no
+bundled `{lang}.json`. See CLAUDE.md › Conventions › Testing for the rule.
 
 
 ## Common Not Converted Pattern (All Calendar Date Tests)

--- a/lib/flutter_ilib.dart
+++ b/lib/flutter_ilib.dart
@@ -16,6 +16,7 @@ export 'ilib_init.dart';
 export 'ilib_locale.dart';
 export 'ilib_localeinfo.dart';
 export 'ilib_numfmt.dart';
+export 'ilib_scriptinfo.dart';
 export 'ilib_timezone.dart';
 
 class FlutterILib extends ChangeNotifier {

--- a/lib/ilib_scriptinfo.dart
+++ b/lib/ilib_scriptinfo.dart
@@ -9,6 +9,11 @@ import 'ilib_init.dart';
 /// flags.
 class ILibScriptInfo {
   /// [script] The ISO 15924 4-letter identifier for the script.
+  ///
+  /// Unlike the JS `ScriptInfo(script, options)` constructor where `script` is
+  /// optional (omitting it yields an instance with no info), Dart requires an
+  /// explicit code. Pass an empty string `''` to replicate the JS no-arg
+  /// behaviour — `_info` will be null and all getters return their defaults.
   ILibScriptInfo(this.script) {
     final Map<String, dynamic>? rootData = ILibLoader.instance.getRootData();
     final Map<String, dynamic>? scripts =

--- a/lib/ilib_scriptinfo.dart
+++ b/lib/ilib_scriptinfo.dart
@@ -1,72 +1,78 @@
-import 'flutter_ilib.dart';
 import 'ilib_init.dart';
 
+/// Information about scripts, based on the ISO 15924 registry.
+///
+/// The script metadata is locale-independent (it lives in `root.json` only,
+/// under the `ilib.data.scripts` key), mirroring the JS `ilib.data.scripts`
+/// global. Each entry maps a 4-letter script code to its number (`nb`),
+/// English name (`nm`), long identifier (`lid`), and the `rtl`/`ime`/`casing`
+/// flags.
 class ILibScriptInfo {
-  /// [script] The ISO 15924 4-letter identifier for the script
-  ILibScriptInfo(String this.script);
+  /// [script] The ISO 15924 4-letter identifier for the script.
+  ILibScriptInfo(this.script) {
+    final Map<String, dynamic>? rootData = ILibLoader.instance.getRootData();
+    final Map<String, dynamic>? scripts =
+        rootData?['ilib.data.scripts'] as Map<String, dynamic>?;
+    _info = scripts?[script] as Map<String, dynamic>?;
+  }
+
   String? script;
+
+  /// Metadata for [script], or null if the script code is unknown.
+  Map<String, dynamic>? _info;
+
+  /// Return an array of all ISO 15924 4-letter script identifiers that this
+  /// copy of ilib knows about, in the order they appear in the data.
+  static List<String> getAllScripts() {
+    final Map<String, dynamic>? rootData = ILibLoader.instance.getRootData();
+    final Map<String, dynamic>? scripts =
+        rootData?['ilib.data.scripts'] as Map<String, dynamic>?;
+    final List<String> result = <String>[];
+    if (scripts != null) {
+      for (final MapEntry<String, dynamic> entry in scripts.entries) {
+        if (entry.key.isNotEmpty && entry.value != null) {
+          result.add(entry.key);
+        }
+      }
+    }
+    return result;
+  }
 
   /// Return the 4-letter ISO 15924 identifier associated with this script.
   String? getCode() {
-    final String jscode1 = 'new ScriptInfo("$script").getCode()';
-    final String result = ILibJS.instance.evaluate(jscode1).stringResult;
-    if (result == null || result.isEmpty || result == 'null') {
-      return null;
-    }
-    return result;
+    return _info == null ? null : script;
   }
 
   /// Get the ISO 15924 code number associated with this script.
   int? getCodeNumber() {
-    final String jscode1 = 'new ScriptInfo("$script").getCodeNumber()';
-    final String result = ILibJS.instance.evaluate(jscode1).stringResult;
-    if (result == null || result.isEmpty || result == 'null') {
-      return 0;
-    }
-    return int.tryParse(result);
+    return (_info?['nb'] as num?)?.toInt() ?? 0;
   }
 
   /// Get the name of this script in English.
   String? getName() {
-    final String jscode1 = 'new ScriptInfo("$script").getName()';
-    final String result = ILibJS.instance.evaluate(jscode1).stringResult;
-    if (result == null || result.isEmpty || result == 'null') {
-      return null;
-    }
-    return result;
+    return _info?['nm'] as String?;
   }
 
   /// Get the long identifier associated with this script.
   String? getLongCode() {
-    final String jscode1 = 'new ScriptInfo("$script").getLongCode()';
-    final String result = ILibJS.instance.evaluate(jscode1).stringResult;
-    if (result == null || result.isEmpty || result == 'null') {
-      return null;
-    }
-    return result;
+    return _info?['lid'] as String?;
   }
 
   /// Return the usual direction that text in this script is written in.<br>
   /// Possible return values are "rtl" for right-to-left,<br>
   /// "ltr" for left-to-right, and "ttb" for top-to-bottom.
   String getScriptDirection() {
-    final String jscode1 = 'new ScriptInfo("$script").getScriptDirection()';
-    final String result = ILibJS.instance.evaluate(jscode1).stringResult;
-    return result;
+    return (_info?['rtl'] as bool?) ?? false ? 'rtl' : 'ltr';
   }
 
   /// Return true if this script typically requires an input method engine
   /// to enter its characters.
   bool getNeedsIME() {
-    final String jscode1 = 'new ScriptInfo("$script").getNeedsIME()';
-    final String result = ILibJS.instance.evaluate(jscode1).stringResult;
-    return result.toLowerCase() == 'true';
+    return (_info?['ime'] as bool?) ?? false;
   }
 
   /// Return true if this script uses lower- and upper-case characters.
   bool getCasing() {
-    final String jscode1 = 'new ScriptInfo("$script").getCasing()';
-    final String result = ILibJS.instance.evaluate(jscode1).stringResult;
-    return result.toLowerCase() == 'true';
+    return (_info?['casing'] as bool?) ?? false;
   }
 }

--- a/test/scriptinfo/scriptinfo_test.dart
+++ b/test/scriptinfo/scriptinfo_test.dart
@@ -2,17 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_ilib/flutter_ilib.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../test_env.dart';
-
 void main() {
-  String testPlatform = '';
   TestWidgetsFlutterBinding.ensureInitialized();
   debugPrint('Testing [scriptinfo_test.dart] file.');
   setUpAll(() async {
-    testPlatform = getTestPlatform();
-    final ILibJS ilibjsinstance = ILibJS.instance;
-    await ilibjsinstance.loadJS();
-    ilibjsinstance.initILib();
+    final ILibLoader ilibjsinstance = ILibLoader.instance;
+    await ilibjsinstance.loadJSON();
     await ilibjsinstance.loadILibLocaleDataAll();
   });
 
@@ -149,6 +144,96 @@ void main() {
       expect(si.getCodeNumber(), 0);
       expect(si.getName(), isNull);
       expect(si.getLongCode(), isNull);
+    });
+
+    test('testScriptGetDefaultLongCode_Berf', () {
+      final ILibScriptInfo si = ILibScriptInfo('Berf');
+      expect(si, isNotNull);
+
+      expect(si.getCode(), 'Berf');
+      expect(si.getCodeNumber(), 258);
+      expect(si.getName(), 'Beria Erfe');
+      expect(si.getLongCode(), 'Beria_Erfe');
+      expect(si.getScriptDirection(), 'ltr');
+      expect(si.getNeedsIME(), isFalse);
+      expect(si.getCasing(), isTrue);
+    });
+
+    test('testScriptGetDefaultLongCode_Gara', () {
+      final ILibScriptInfo si = ILibScriptInfo('Gara');
+      expect(si, isNotNull);
+
+      expect(si.getCode(), 'Gara');
+      expect(si.getCodeNumber(), 164);
+      expect(si.getName(), 'Garay');
+      expect(si.getLongCode(), 'Garay');
+      expect(si.getScriptDirection(), 'rtl');
+      expect(si.getNeedsIME(), isFalse);
+      expect(si.getCasing(), isTrue);
+    });
+
+    test('testScriptGetDefaultLongCodeKits', () {
+      final ILibScriptInfo si = ILibScriptInfo('Kits');
+      expect(si, isNotNull);
+
+      expect(si.getCode(), 'Kits');
+      expect(si.getCodeNumber(), 288);
+      expect(si.getName(), 'Khitan small script');
+      expect(si.getLongCode(), 'Khitan_Small_Script');
+      expect(si.getScriptDirection(), 'ltr');
+      expect(si.getNeedsIME(), isTrue);
+      expect(si.getCasing(), isFalse);
+    });
+
+    test('testScriptGetDefaultLongCodeMend', () {
+      final ILibScriptInfo si = ILibScriptInfo('Mend');
+      expect(si, isNotNull);
+
+      expect(si.getCode(), 'Mend');
+      expect(si.getCodeNumber(), 438);
+      expect(si.getName(), 'Mende Kikakui');
+      expect(si.getLongCode(), 'Mende_Kikakui');
+      expect(si.getScriptDirection(), 'rtl');
+      expect(si.getNeedsIME(), isTrue);
+      expect(si.getCasing(), isFalse);
+    });
+
+    test('testScriptGetDefaultLongCodePauc', () {
+      final ILibScriptInfo si = ILibScriptInfo('Pauc');
+      expect(si, isNotNull);
+
+      expect(si.getCode(), 'Pauc');
+      expect(si.getCodeNumber(), 263);
+      expect(si.getName(), 'Pau Cin Hau');
+      expect(si.getLongCode(), 'Pau_Cin_Hau');
+      expect(si.getScriptDirection(), 'ltr');
+      expect(si.getNeedsIME(), isFalse);
+      expect(si.getCasing(), isFalse);
+    });
+
+    test('testScriptGetDefaultLongCode_Tols', () {
+      final ILibScriptInfo si = ILibScriptInfo('Tols');
+      expect(si, isNotNull);
+
+      expect(si.getCode(), 'Tols');
+      expect(si.getCodeNumber(), 299);
+      expect(si.getName(), 'Tolong Siki');
+      expect(si.getLongCode(), 'Tolong_Siki');
+      expect(si.getScriptDirection(), 'ltr');
+      expect(si.getNeedsIME(), isFalse);
+      expect(si.getCasing(), isFalse);
+    });
+
+    test('testScriptGetAllScripts', () {
+      final List<String> scripts = ILibScriptInfo.getAllScripts();
+      expect(scripts, isNotNull);
+
+      expect(scripts.length, 224);
+      expect(scripts[0], 'Adlm');
+      expect(scripts[1], 'Afak');
+      expect(scripts[2], 'Aghb');
+      expect(scripts[4], 'Arab');
+      expect(scripts[scripts.length - 1], 'Zzzz');
     });
 
     test('testScriptInfo_ar_EG', () {
@@ -396,15 +481,6 @@ void main() {
 
     test('testScriptInfo_en_KE', () {
       final ILibLocaleInfo li = ILibLocaleInfo('en-KE');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Latn');
-      expect(scinfo.getScriptDirection(), 'ltr');
-    });
-
-    test('testScriptInfo_en_KR', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('en-KR');
       final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
       expect(li, isNotNull);
       expect(scinfo, isNotNull);
@@ -709,15 +785,6 @@ void main() {
       expect(scinfo.getScriptDirection(), 'ltr');
     });
 
-    test('testScriptInfo_fa_AF', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('fa-AF');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Arab');
-      expect(scinfo.getScriptDirection(), 'rtl');
-    });
-
     test('testScriptInfo_fa_IR', () {
       final ILibLocaleInfo li = ILibLocaleInfo('fa-IR');
       final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
@@ -835,15 +902,6 @@ void main() {
       expect(scinfo.getScriptDirection(), 'ltr');
     });
 
-    test('testScriptInfo_hr_HU', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('hr-HU');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Latn');
-      expect(scinfo.getScriptDirection(), 'ltr');
-    });
-
     test('testScriptInfo_id_ID', () {
       final ILibLocaleInfo li = ILibLocaleInfo('id-ID');
       final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
@@ -889,15 +947,6 @@ void main() {
       expect(scinfo.getScriptDirection(), 'ltr');
     });
 
-    test('testScriptInfo_kk_KZ', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('kk-KZ');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Cyrl');
-      expect(scinfo.getScriptDirection(), 'ltr');
-    });
-
     test('testScriptInfo_kn_IN', () {
       final ILibLocaleInfo li = ILibLocaleInfo('kn-IN');
       final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
@@ -916,14 +965,6 @@ void main() {
       expect(scinfo.getScriptDirection(), 'ltr');
     });
 
-    test('testScriptInfo_ku_IQ', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('ku-IQ');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Latn');
-      expect(scinfo.getScriptDirection(), 'ltr');
-    });
     test('testScriptInfo_ku_Arab_IQ', () {
       final ILibLocaleInfo li = ILibLocaleInfo('ku-Arab-IQ');
       final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
@@ -1023,33 +1064,6 @@ void main() {
       expect(scinfo.getScriptDirection(), 'ltr');
     });
 
-    test('testScriptInfo_pa_Guru_IN', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('pa-Guru-IN');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Guru');
-      expect(scinfo.getScriptDirection(), 'ltr');
-    });
-
-    test('testScriptInfo_pa', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('pa');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Guru');
-      expect(scinfo.getScriptDirection(), 'ltr');
-    });
-
-    test('testScriptInfo_pa_PK', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('pa-PK');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Arab');
-      expect(scinfo.getScriptDirection(), 'rtl');
-    });
-
     test('testScriptInfo_pl_PL', () {
       final ILibLocaleInfo li = ILibLocaleInfo('pl-PL');
       final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
@@ -1083,15 +1097,6 @@ void main() {
       expect(li, isNotNull);
       expect(scinfo, isNotNull);
       expect(li.getScript(), 'Latn');
-      expect(scinfo.getScriptDirection(), 'ltr');
-    });
-
-    test('testScriptInfo_sr_Cyrl_RS', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('sr-Cyrl-RS');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Cyrl');
       expect(scinfo.getScriptDirection(), 'ltr');
     });
 
@@ -1374,15 +1379,6 @@ void main() {
       expect(scinfo.getScriptDirection(), 'ltr');
     });
 
-    test('testScriptInfo_mn_MN', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('mn-MN');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Cyrl');
-      expect(scinfo.getScriptDirection(), 'ltr');
-    });
-
     test('testScriptInfo_es_CA', () {
       final ILibLocaleInfo li = ILibLocaleInfo('es-CA');
       final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
@@ -1419,66 +1415,12 @@ void main() {
       expect(scinfo.getScriptDirection(), 'ltr');
     });
 
-    test('testScriptInfo_ha', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('ha');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Latn');
-      expect(scinfo.getScriptDirection(), 'ltr');
-    });
-
-    test('testScriptInfo_az', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('az');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Latn');
-      expect(scinfo.getScriptDirection(), 'ltr');
-    });
-
-    test('testScriptInfo_ha_NG', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('ha-NG');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Latn');
-      expect(scinfo.getScriptDirection(), 'ltr');
-    });
-
-    test('testScriptInfo_ha_CM', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('ha-CM');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Arab');
-      expect(scinfo.getScriptDirection(), 'rtl');
-    });
-
-    test('testScriptInfo_ha_SD', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('ha-SD');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Arab');
-      expect(scinfo.getScriptDirection(), 'rtl');
-    });
-
     test('testScriptInfo_or_IN', () {
       final ILibLocaleInfo li = ILibLocaleInfo('or-IN');
       final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
       expect(li, isNotNull);
       expect(scinfo, isNotNull);
       expect(li.getScript(), 'Orya');
-      expect(scinfo.getScriptDirection(), 'ltr');
-    });
-
-    test('testScriptInfo_az_AZ', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('az-AZ');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Latn');
       expect(scinfo.getScriptDirection(), 'ltr');
     });
 
@@ -1518,96 +1460,6 @@ void main() {
       expect(scinfo.getScriptDirection(), 'rtl');
     });
 
-    test('testScriptInfo_ar_BH', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('ar-BH');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Arab');
-      expect(scinfo.getScriptDirection(), 'rtl');
-    });
-
-    test('testScriptInfo_ar_DJ', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('ar-DJ');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Arab');
-      expect(scinfo.getScriptDirection(), 'rtl');
-    });
-
-    test('testScriptInfo_ar_DZ', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('ar-DZ');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Arab');
-      expect(scinfo.getScriptDirection(), 'rtl');
-    });
-
-    test('testScriptInfo_ar_JO', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('ar-JO');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Arab');
-      expect(scinfo.getScriptDirection(), 'rtl');
-    });
-
-    test('testScriptInfo_ar_KW', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('ar-KW');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Arab');
-      expect(scinfo.getScriptDirection(), 'rtl');
-    });
-
-    test('testScriptInfo_ar_LB', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('ar-LB');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Arab');
-      expect(scinfo.getScriptDirection(), 'rtl');
-    });
-
-    test('testScriptInfo_ar_LY', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('ar-LY');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Arab');
-      expect(scinfo.getScriptDirection(), 'rtl');
-    });
-
-    test('testScriptInfo_ar_MR', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('ar-MR');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Arab');
-      expect(scinfo.getScriptDirection(), 'rtl');
-    });
-
-    test('testScriptInfo_ar_OM', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('ar-OM');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Arab');
-      expect(scinfo.getScriptDirection(), 'rtl');
-    });
-
-    test('testScriptInfo_ar_QA', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('ar-QA');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Arab');
-      expect(scinfo.getScriptDirection(), 'rtl');
-    });
-
     test('testScriptInfo_ar_SA', () {
       final ILibLocaleInfo li = ILibLocaleInfo('ar-SA');
       final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
@@ -1615,366 +1467,6 @@ void main() {
       expect(scinfo, isNotNull);
       expect(li.getScript(), 'Arab');
       expect(scinfo.getScriptDirection(), 'rtl');
-    });
-
-    test('testScriptInfo_ar_SD', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('ar-SD');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Arab');
-      expect(scinfo.getScriptDirection(), 'rtl');
-    });
-
-    test('testScriptInfo_ar_SY', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('ar-SY');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Arab');
-      expect(scinfo.getScriptDirection(), 'rtl');
-    });
-
-    test('testScriptInfo_ar_TN', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('ar-TN');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Arab');
-      expect(scinfo.getScriptDirection(), 'rtl');
-    });
-
-    test('testScriptInfo_ar_YE', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('ar-YE');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Arab');
-      expect(scinfo.getScriptDirection(), 'rtl');
-    });
-
-    test('testScriptInfo_en_ET', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('en-ET');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Latn');
-      expect(scinfo.getScriptDirection(), 'ltr');
-    });
-
-    test('testScriptInfo_en_GM', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('en-GM');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Latn');
-      expect(scinfo.getScriptDirection(), 'ltr');
-    });
-
-    test('testScriptInfo_en_LR', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('en-LR');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Latn');
-      expect(scinfo.getScriptDirection(), 'ltr');
-    });
-
-    test('testScriptInfo_en_PK', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('en-PK');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Latn');
-      expect(scinfo.getScriptDirection(), 'ltr');
-    });
-
-    test('testScriptInfo_en_RW', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('en-RW');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Latn');
-      expect(scinfo.getScriptDirection(), 'ltr');
-    });
-
-    test('testScriptInfo_en_SD', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('en-SD');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Latn');
-      expect(scinfo.getScriptDirection(), 'ltr');
-    });
-
-    test('testScriptInfo_en_SL', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('en-SL');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Latn');
-      expect(scinfo.getScriptDirection(), 'ltr');
-    });
-
-    test('testScriptInfo_en_TZ', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('en-TZ');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Latn');
-      expect(scinfo.getScriptDirection(), 'ltr');
-    });
-
-    test('testScriptInfo_es_CR', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('es-CR');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Latn');
-      expect(scinfo.getScriptDirection(), 'ltr');
-    });
-
-    test('testScriptInfo_es_GQ', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('es-GQ');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Latn');
-      expect(scinfo.getScriptDirection(), 'ltr');
-    });
-
-    test('testScriptInfo_es_PH', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('es-PH');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Latn');
-      expect(scinfo.getScriptDirection(), 'ltr');
-    });
-
-    test('testScriptInfo_fr_BF', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('fr-BF');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Latn');
-      expect(scinfo.getScriptDirection(), 'ltr');
-    });
-
-    test('testScriptInfo_fr_BJ', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('fr-BJ');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Latn');
-      expect(scinfo.getScriptDirection(), 'ltr');
-    });
-
-    test('testScriptInfo_fr_CD', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('fr-CD');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Latn');
-      expect(scinfo.getScriptDirection(), 'ltr');
-    });
-
-    test('testScriptInfo_fr_CF', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('fr-CF');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Latn');
-      expect(scinfo.getScriptDirection(), 'ltr');
-    });
-
-    test('testScriptInfo_fr_CG', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('fr-CG');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Latn');
-      expect(scinfo.getScriptDirection(), 'ltr');
-    });
-
-    test('testScriptInfo_fr_CI', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('fr-CI');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Latn');
-      expect(scinfo.getScriptDirection(), 'ltr');
-    });
-
-    test('testScriptInfo_fr_CM', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('fr-CM');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Latn');
-      expect(scinfo.getScriptDirection(), 'ltr');
-    });
-
-    test('testScriptInfo_fr_GQ', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('fr-GQ');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Latn');
-      expect(scinfo.getScriptDirection(), 'ltr');
-    });
-
-    test('testScriptInfo_fr_DJ', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('fr-DJ');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Latn');
-      expect(scinfo.getScriptDirection(), 'ltr');
-    });
-
-    test('testScriptInfo_fr_DZ', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('fr-DZ');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Latn');
-      expect(scinfo.getScriptDirection(), 'ltr');
-    });
-
-    test('testScriptInfo_fr_GA', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('fr-GA');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Latn');
-      expect(scinfo.getScriptDirection(), 'ltr');
-    });
-
-    test('testScriptInfo_fr_GN', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('fr-GN');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Latn');
-      expect(scinfo.getScriptDirection(), 'ltr');
-    });
-
-    test('testScriptInfo_fr_LB', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('fr-LB');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Latn');
-      expect(scinfo.getScriptDirection(), 'ltr');
-    });
-
-    test('testScriptInfo_fr_ML', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('fr-ML');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Latn');
-      expect(scinfo.getScriptDirection(), 'ltr');
-    });
-
-    test('testScriptInfo_fr_RW', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('fr-RW');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Latn');
-      expect(scinfo.getScriptDirection(), 'ltr');
-    });
-
-    test('testScriptInfo_fr_SN', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('fr-SN');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Latn');
-      expect(scinfo.getScriptDirection(), 'ltr');
-    });
-
-    test('testScriptInfo_fr_TG', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('fr-TG');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Latn');
-      expect(scinfo.getScriptDirection(), 'ltr');
-    });
-
-    test('testScriptInfo_ms_SG', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('ms-SG');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Latn');
-      expect(scinfo.getScriptDirection(), 'ltr');
-    });
-
-    test('testScriptInfo_pa_Arab_PK', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('pa-Arab-PK');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Arab');
-      expect(scinfo.getScriptDirection(), 'rtl');
-    });
-
-    test('testScriptInfo_pt_AO', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('pt-AO');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Latn');
-      expect(scinfo.getScriptDirection(), 'ltr');
-    });
-
-    test('testScriptInfo_pt_GQ', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('pt-GQ');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Latn');
-      expect(scinfo.getScriptDirection(), 'ltr');
-    });
-
-    test('testScriptInfo_pt_CV', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('pt-CV');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Latn');
-      expect(scinfo.getScriptDirection(), 'ltr');
-    });
-
-    test('testScriptInfo_ur_PK', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('ur-PK');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Arab');
-      expect(scinfo.getScriptDirection(), 'rtl');
-    });
-
-    test('testScriptInfo_zh_Hans_SG', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('zh-Hans-SG');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Hans');
-      expect(scinfo.getScriptDirection(), 'ltr');
-    });
-
-    test('testScriptInfo_zh_Hans_MY', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('zh-Hans-MY');
-      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
-      expect(li, isNotNull);
-      expect(scinfo, isNotNull);
-      expect(li.getScript(), 'Hans');
-      expect(scinfo.getScriptDirection(), 'ltr');
     });
 
     test('testScriptInfo_ka_GE', () {
@@ -1986,8 +1478,21 @@ void main() {
       expect(scinfo.getScriptDirection(), 'ltr');
     });
 
-    test('testScriptInfo_es_ES', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('ca-ES');
+    // Language-only cases: the argument is a bare language (no region) that is
+    // itself supported — a bundled `{lang}.json` backs the result (not a root
+    // default). Kept even though the bare code is not a `locales.json` entry,
+    // because it exercises real language-level data for a supported language.
+    test('testScriptInfo_pa', () {
+      final ILibLocaleInfo li = ILibLocaleInfo('pa');
+      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
+      expect(li, isNotNull);
+      expect(scinfo, isNotNull);
+      expect(li.getScript(), 'Guru');
+      expect(scinfo.getScriptDirection(), 'ltr');
+    });
+
+    test('testScriptInfo_ha', () {
+      final ILibLocaleInfo li = ILibLocaleInfo('ha');
       final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
       expect(li, isNotNull);
       expect(scinfo, isNotNull);
@@ -1995,8 +1500,8 @@ void main() {
       expect(scinfo.getScriptDirection(), 'ltr');
     });
 
-    test('testScriptInfo_ha', () {
-      final ILibLocaleInfo li = ILibLocaleInfo('ha');
+    test('testScriptInfo_az', () {
+      final ILibLocaleInfo li = ILibLocaleInfo('az');
       final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
       expect(li, isNotNull);
       expect(scinfo, isNotNull);

--- a/test/scriptinfo/scriptinfo_test.dart
+++ b/test/scriptinfo/scriptinfo_test.dart
@@ -1064,6 +1064,15 @@ void main() {
       expect(scinfo.getScriptDirection(), 'ltr');
     });
 
+    test('testScriptInfo_pa_Guru_IN', () {
+      final ILibLocaleInfo li = ILibLocaleInfo('pa-Guru-IN');
+      final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());
+      expect(li, isNotNull);
+      expect(scinfo, isNotNull);
+      expect(li.getScript(), 'Guru');
+      expect(scinfo.getScriptDirection(), 'ltr');
+    });
+
     test('testScriptInfo_pl_PL', () {
       final ILibLocaleInfo li = ILibLocaleInfo('pl-PL');
       final ILibScriptInfo scinfo = ILibScriptInfo(li.getScript());


### PR DESCRIPTION
### Checklist

The following lists affects Pub Points on pub.dev when the package is published.
* [ ] Passed the all tests.
* [ ] Verified that the example app works.
* [ ] Executed the `dart format` command.
* [ ] Added the API description is added if necessary.

## Summary

- Port `ILibScriptInfo` from JS interop to pure Dart (`lib/ilib_scriptinfo.dart`)
- Convert `testscriptinfo.js` → `test/scriptinfo/scriptinfo_test.dart` (161 tests, all pass)
- Export `ILibScriptInfo` from `lib/flutter_ilib.dart`

## Changes

### Implementation
- `ILibScriptInfo(String script)` reads from `ilib.data.scripts` in `root.json` (locale-independent)
- `getAllScripts()` returns all ISO 15924 codes from the same data
- All getters (`getCode`, `getCodeNumber`, `getName`, `getLongCode`, `getScriptDirection`, `getNeedsIME`, `getCasing`) match JS originals

### Test coverage
- 161 tests converted 1:1 from `js/test/root/testscriptinfo.js` at v14.22.0
- 85 JS tests skipped (N/A — locales not in `locales.json`)

### Documentation
- `ilib_scriptinfo.dart`: constructor comment explaining JS optional arg vs Dart required arg
- `docs/conversion-guide.md`: "Intentional API Differences" table; locale scope rules for script-explicit 3-part and language-only locales
- `CLAUDE.md`: concise locale scope rules for the two new cases
- `docs/test-mapping.md`: updated to reflect ILibScriptInfo conversion status

## Test plan
- [ ] `flutter test test/scriptinfo/` — 161 tests pass
- [ ] `flutter analyze` — no issues
