### PR TITLE
Add script to assemble bundled iLib JS assets

### DIFF
--- a/execute_unit_test.sh
+++ b/execute_unit_test.sh
@@ -40,12 +40,19 @@ run_linux_flutter_test() {
 test_log "Set LIBQUICKJSC_TEST_PATH"
 export LIBQUICKJSC_TEST_PATH="${PROJECT_ROOT}/test/linux/libquickjs_c_bridge_plugin.so"
 
+# Resolve dependencies once up front. Each `flutter test` below runs with
+# --no-pub so it doesn't re-run `pub get` (and re-print "Downloading
+# packages..." + the outdated-package list) for every one of the test files.
+test_log "Resolve dependencies (flutter pub get)..."
+flutter pub get
+
 FAILED_UNIT_TESTS=()
 FAILED_INTEGRATION_TESTS=()
 RUN_UNIT_TESTS=false
 RUN_INTEGRATION_TESTS=false
-# Suppress info-level logs during test execution
-FLUTTER_OPTIONS="--dart-define=TEST_MODE=true"
+# Suppress info-level logs during test execution.
+# --no-pub: skip the implicit `pub get` on every `flutter test` (run once above).
+FLUTTER_OPTIONS="--dart-define=TEST_MODE=true --no-pub"
 
 # --- Test functions ---
 
@@ -77,6 +84,9 @@ run_integration_tests() {
   local previous_libquickjsc_path="${LIBQUICKJSC_PATH:-}"
   pushd example > /dev/null
   export LIBQUICKJSC_PATH="${PROJECT_ROOT}/test/linux/libquickjs_c_bridge_plugin.so"
+  # example/ has its own pubspec; resolve it once, then run each test --no-pub.
+  test_log "Resolve example dependencies (flutter pub get)..."
+  flutter pub get
   for test_file in $(find integration_test/ -name '*_test.dart'); do
     if ! run_linux_flutter_test "$test_file" $FLUTTER_OPTIONS -d linux; then
       FAILED_INTEGRATION_TESTS+=("example/$test_file")

--- a/scripts/assemble_ilib/.gitignore
+++ b/scripts/assemble_ilib/.gitignore
@@ -1,0 +1,3 @@
+# Throwaway install/output directory created by generate_assets.sh.
+build/
+node_modules/

--- a/scripts/assemble_ilib/README.md
+++ b/scripts/assemble_ilib/README.md
@@ -1,0 +1,79 @@
+# assemble_ilib
+
+Regenerates the iLib JavaScript that `flutter_ilib` ships under `assets/`:
+
+| Output | Description |
+| --- | --- |
+| `assets/js/ilib-init.js` | The assembled, minified iLib JS runtime. |
+| `assets/locales/<lang>.js` | Per-language CLDR/locale data bundles. |
+
+These are produced by the [`ilib-assemble`](https://www.npmjs.com/package/ilib-assemble)
+tool run against the legacy monolithic [`ilib`](https://www.npmjs.com/package/ilib)
+package (v14).
+
+## Usage
+
+```bash
+cd scripts/assemble_ilib
+./generate_assets.sh
+```
+
+The script downloads the required npm packages into a throwaway `build/`
+directory (git-ignored), runs the assembler, copies the results into
+`assets/`, then removes `build/`. It does **not** require a global npm install.
+
+### Previewing without touching `assets/`
+
+To generate the output somewhere else and diff it before committing:
+
+```bash
+./generate_assets.sh --dry-run                 # writes to a temp dir, prints its path
+./generate_assets.sh --out-dir /tmp/ilib-preview
+```
+
+Both write the same `js/ilib-init.js` + `locales/<lang>.js` layout into the
+target directory and leave `assets/` untouched. Compare, then copy over if it
+looks right:
+
+```bash
+./generate_assets.sh --out-dir /tmp/ilib-preview
+diff -r /tmp/ilib-preview/locales assets/locales
+cp -r /tmp/ilib-preview/js/. assets/js/ && cp -r /tmp/ilib-preview/locales/. assets/locales/
+```
+
+Run `./generate_assets.sh --help` for the full option list.
+
+### Inputs
+
+| File | Purpose |
+| --- | --- |
+| `ilib-inc.js` | The legacy `!depends` list — which iLib modules to bundle into `ilib-init.js`. Edit this to add/remove iLib classes. |
+| `locales.json` | The set of BCP-47 locales to generate data for (`{ "locales": [...] }`). Edit this to change locale coverage. |
+
+Locale bundles are emitted per **language** (e.g. `en.js` covers `en-US`,
+`en-GB`, … listed in `locales.json`).
+
+### Options
+
+Pass as command-line arguments (`./generate_assets.sh --help` for the full list):
+
+| Option | Default | Effect |
+| --- | --- | --- |
+| `--ilib-version VER` | `latest` | Pin a specific `ilib` npm version (any npm version/tag). |
+| `-o, --out-dir DIR` | `assets/` | Write output to `DIR` instead of `assets/`. |
+| `--dry-run` | — | Write output to a temp dir; leave `assets/` untouched. |
+| `--keep-build` | — | Keep the intermediate `build/` dir for inspection. |
+
+`ilib-assemble` always installs the latest release. `--ilib-version` defaults to
+the latest release when omitted.
+
+Example — pin the ilib version and keep the build dir:
+
+```bash
+./generate_assets.sh --ilib-version 14.22.0 --keep-build
+```
+
+## After regenerating
+
+Review the diff (`git diff assets/`) and run the test suite before committing —
+the generated JS is consumed at runtime by the Dart bindings.

--- a/scripts/assemble_ilib/README.md
+++ b/scripts/assemble_ilib/README.md
@@ -60,12 +60,18 @@ Pass as command-line arguments (`./generate_assets.sh --help` for the full list)
 | Option | Default | Effect |
 | --- | --- | --- |
 | `--ilib-version VER` | `latest` | Pin a specific `ilib` npm version (any npm version/tag). |
+| `--ilib-path DIR` | — | Use an existing ilib install at `DIR` instead of downloading it. Overrides `--ilib-version`. |
 | `-o, --out-dir DIR` | `assets/` | Write output to `DIR` instead of `assets/`. |
 | `--dry-run` | — | Write output to a temp dir; leave `assets/` untouched. |
 | `--keep-build` | — | Keep the intermediate `build/` dir for inspection. |
 
 `ilib-assemble` always installs the latest release. `--ilib-version` defaults to
 the latest release when omitted.
+
+`--ilib-version` and `--ilib-path` select where `ilib` comes from and are
+mutually exclusive in effect. If both are given, `--ilib-path` wins: the local
+install is used, `--ilib-version` is ignored, and the script prints a note
+saying so.
 
 Example — pin the ilib version and keep the build dir:
 

--- a/scripts/assemble_ilib/generate_assets.sh
+++ b/scripts/assemble_ilib/generate_assets.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+#
+# generate_assets.sh
+#
+# Downloads the latest `ilib` and `ilib-assemble` npm packages and regenerates
+# the iLib JavaScript that flutter_ilib ships under `assets/`:
+#
+#   assets/js/ilib-init.js      - the assembled (minified) iLib JS runtime
+#   assets/locales/<lang>.js    - per-language CLDR/locale data bundles
+#
+# The set of iLib modules to include is driven by `ilib-inc.js` (the legacy
+# `!depends` list) and the set of locales by `locales.json`.
+#
+# Usage:
+#   ./generate_assets.sh [options]
+#
+# Options (see --help for the full list):
+#   --ilib-version VER            pin a specific `ilib` npm version (default: latest)
+#   -o, --out-dir DIR             write output to DIR instead of assets/
+#   --dry-run                     write output to a temp dir; leave assets/ untouched
+#   --keep-build                  keep the intermediate build/ directory for inspection
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+INC_FILE="$SCRIPT_DIR/ilib-inc.js"
+LOCALES_FILE="$SCRIPT_DIR/locales.json"
+BUILD_DIR="$SCRIPT_DIR/build"
+OUT_DIR="$BUILD_DIR/out"
+
+ASSETS_JS_DIR="$PROJECT_ROOT/assets/js"
+ASSETS_LOCALES_DIR="$PROJECT_ROOT/assets/locales"
+OUT_JS_NAME="ilib-init.js"
+
+# Versions to install (npm dist-tags or explicit versions). `ilib` is the
+# legacy monolithic package (v14 line); `ilib-assemble` is the standalone
+# assembler that supports it via --legacyilib. `ilib` defaults to the latest
+# release (override with --ilib-version); `ilib-assemble` always uses latest.
+ILIB_VERSION="latest"
+ILIB_ASSEMBLE_VERSION="latest"
+
+log() { printf '\033[1;34m[assemble]\033[0m %s\n' "$1"; }
+err() { printf '\033[1;31m[assemble] error:\033[0m %s\n' "$1" >&2; }
+
+usage() {
+  cat <<EOF
+generate_assets.sh - regenerate the iLib JS bundled under assets/
+
+Downloads ilib + ilib-assemble and rebuilds:
+  assets/js/ilib-init.js     assembled (minified) iLib JS runtime
+  assets/locales/<lang>.js   per-language locale data bundles
+
+Usage:
+  ./generate_assets.sh [options]
+
+Run with no arguments to regenerate everything under assets/ using the default
+(latest) versions.
+
+Options:
+  -h, --help                     Show this help and exit.
+      --ilib-version VER         Version of the ilib npm package to install.
+                                 Accepts any npm version/tag (e.g. 14.22.0,
+                                 ^14, latest).                (default: latest)
+  -o, --out-dir DIR              Write the generated files into DIR (as DIR/js
+                                 and DIR/locales) instead of the project's
+                                 assets/. Use this to inspect/diff before
+                                 committing.
+      --dry-run                  Like --out-dir but writes to a fresh temp
+                                 directory and prints its path. Never touches
+                                 assets/.
+      --keep-build               Keep the intermediate build/ dir for
+                                 inspection.                   (default: removed)
+
+Inputs (edit these to change what is generated):
+  ilib-inc.js    legacy !depends list of iLib modules to bundle
+  locales.json   { "locales": [...] } list of BCP-47 locales
+
+Examples:
+  ./generate_assets.sh
+  ./generate_assets.sh --dry-run
+  ./generate_assets.sh --out-dir /tmp/ilib-preview
+  ./generate_assets.sh --ilib-version 14.22.0
+EOF
+}
+
+# --- argument parsing ------------------------------------------------------
+DEST_ROOT=""   # empty => write to the project's assets/
+DRY_RUN=0
+KEEP_BUILD=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -h|--help) usage; exit 0 ;;
+    --ilib-version)
+      [ $# -ge 2 ] || { err "$1 requires a version argument"; exit 2; }
+      ILIB_VERSION="$2"; shift 2 ;;
+    -o|--out-dir)
+      [ $# -ge 2 ] || { err "$1 requires a directory argument"; exit 2; }
+      DEST_ROOT="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    --keep-build) KEEP_BUILD=1; shift ;;
+    *) err "unknown argument: $1"; echo; usage >&2; exit 2 ;;
+  esac
+done
+
+# --- sanity checks ---------------------------------------------------------
+command -v npm  >/dev/null 2>&1 || { err "npm is required but not found in PATH.";  exit 1; }
+command -v node >/dev/null 2>&1 || { err "node is required but not found in PATH."; exit 1; }
+[ -f "$INC_FILE" ]     || { err "missing $INC_FILE";     exit 1; }
+[ -f "$LOCALES_FILE" ] || { err "missing $LOCALES_FILE"; exit 1; }
+
+# --- 1. prepare an isolated build directory --------------------------------
+# Everything npm-related lives under build/ so the source tree stays clean.
+log "Preparing build directory: $BUILD_DIR"
+rm -rf "$OUT_DIR"
+mkdir -p "$BUILD_DIR" "$OUT_DIR"
+if [ ! -f "$BUILD_DIR/package.json" ]; then
+  cat > "$BUILD_DIR/package.json" <<'JSON'
+{
+  "name": "flutter-ilib-assemble-build",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Throwaway install dir for regenerating flutter_ilib assets."
+}
+JSON
+fi
+
+# --- 2. install ilib + ilib-assemble ---------------------------------------
+log "Installing ilib@${ILIB_VERSION} and ilib-assemble@${ILIB_ASSEMBLE_VERSION}..."
+(cd "$BUILD_DIR" && npm install --no-audit --no-fund \
+  "ilib@${ILIB_VERSION}" "ilib-assemble@${ILIB_ASSEMBLE_VERSION}")
+
+ILIB_PATH="$BUILD_DIR/node_modules/ilib"
+ASSEMBLE_BIN="$BUILD_DIR/node_modules/.bin/ilib-assemble"
+[ -d "$ILIB_PATH" ]    || { err "ilib package not found at $ILIB_PATH"; exit 1; }
+[ -x "$ASSEMBLE_BIN" ] || { err "ilib-assemble binary not found at $ASSEMBLE_BIN"; exit 1; }
+
+INSTALLED_ILIB="$(node -p "require('$ILIB_PATH/package.json').version")"
+INSTALLED_ASSEMBLE="$(node -p "require('$BUILD_DIR/node_modules/ilib-assemble/package.json').version")"
+log "Resolved versions: ilib ${INSTALLED_ILIB}, ilib-assemble ${INSTALLED_ASSEMBLE}"
+
+# --- 3. run the legacy-ilib assembler --------------------------------------
+# Produces OUT_DIR/ilib-init.js (runtime) plus one <lang>.js per language.
+log "Assembling iLib runtime + locale data..."
+"$ASSEMBLE_BIN" \
+  --legacyilib \
+  --ilibPath "$ILIB_PATH" \
+  --ilibincPath "$INC_FILE" \
+  --localefile "$LOCALES_FILE" \
+  --outjsFileName "$OUT_JS_NAME" \
+  --compressed \
+  "$OUT_DIR"
+
+[ -f "$OUT_DIR/$OUT_JS_NAME" ] || { err "assembler did not produce $OUT_JS_NAME"; exit 1; }
+
+# --- 4. sync outputs into the destination ----------------------------------
+# Default destination is the project's assets/. --out-dir / --dry-run redirect
+# it elsewhere so the output can be inspected before touching assets/.
+if [ "$DRY_RUN" = "1" ] && [ -z "$DEST_ROOT" ]; then
+  DEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/ilib-assets.XXXXXX")"
+fi
+
+if [ -n "$DEST_ROOT" ]; then
+  DEST_JS_DIR="$DEST_ROOT/js"
+  DEST_LOCALES_DIR="$DEST_ROOT/locales"
+  log "Writing to output directory (assets/ left untouched): $DEST_ROOT"
+else
+  DEST_JS_DIR="$ASSETS_JS_DIR"
+  DEST_LOCALES_DIR="$ASSETS_LOCALES_DIR"
+fi
+
+log "Updating $DEST_JS_DIR/$OUT_JS_NAME"
+mkdir -p "$DEST_JS_DIR"
+cp "$OUT_DIR/$OUT_JS_NAME" "$DEST_JS_DIR/$OUT_JS_NAME"
+
+log "Refreshing $DEST_LOCALES_DIR/*.js"
+mkdir -p "$DEST_LOCALES_DIR"
+# Remove stale language bundles so dropped locales don't linger.
+rm -f "$DEST_LOCALES_DIR"/*.js
+locale_count=0
+for f in "$OUT_DIR"/*.js; do
+  base="$(basename "$f")"
+  [ "$base" = "$OUT_JS_NAME" ] && continue
+  cp "$f" "$DEST_LOCALES_DIR/$base"
+  locale_count=$((locale_count + 1))
+done
+log "Wrote 1 runtime file and ${locale_count} locale bundles."
+
+# --- 5. cleanup ------------------------------------------------------------
+if [ "$KEEP_BUILD" = "1" ]; then
+  log "--keep-build set; leaving $BUILD_DIR in place."
+else
+  log "Cleaning up build directory."
+  rm -rf "$BUILD_DIR"
+fi
+
+log "Done (ilib ${INSTALLED_ILIB} / ilib-assemble ${INSTALLED_ASSEMBLE})."
+if [ -n "$DEST_ROOT" ]; then
+  log "Output written to: $DEST_ROOT"
+  log "assets/ was NOT modified. Review, then copy over if it looks correct."
+fi

--- a/scripts/assemble_ilib/generate_assets.sh
+++ b/scripts/assemble_ilib/generate_assets.sh
@@ -16,6 +16,7 @@
 #
 # Options (see --help for the full list):
 #   --ilib-version VER            pin a specific `ilib` npm version (default: latest)
+#   --ilib-path DIR               use an existing ilib install instead of downloading
 #   -o, --out-dir DIR             write output to DIR instead of assets/
 #   --dry-run                     write output to a temp dir; leave assets/ untouched
 #   --keep-build                  keep the intermediate build/ directory for inspection
@@ -63,6 +64,9 @@ Options:
       --ilib-version VER         Version of the ilib npm package to install.
                                  Accepts any npm version/tag (e.g. 14.22.0,
                                  ^14, latest).                (default: latest)
+      --ilib-path DIR            Use an existing ilib package at DIR instead of
+                                 downloading it (skips the ilib install).
+                                 Overrides --ilib-version.
   -o, --out-dir DIR              Write the generated files into DIR (as DIR/js
                                  and DIR/locales) instead of the project's
                                  assets/. Use this to inspect/diff before
@@ -82,21 +86,35 @@ Examples:
   ./generate_assets.sh --dry-run
   ./generate_assets.sh --out-dir /tmp/ilib-preview
   ./generate_assets.sh --ilib-version 14.22.0
+  ./generate_assets.sh --ilib-path ./node_modules/ilib
 EOF
 }
 
 # --- argument parsing ------------------------------------------------------
-DEST_ROOT=""   # empty => write to the project's assets/
+DEST_ROOT=""       # empty => write to the project's assets/
+ILIB_PATH_ARG=""   # empty => download ilib; else use this existing install
+ILIB_VERSION_SET=0 # whether --ilib-version was passed explicitly
 DRY_RUN=0
 KEEP_BUILD=0
+# Ensure the option in $1 was given a real value in $2 (present, and not another
+# option starting with '-'). Exits with an error otherwise.
+require_value() {
+  case "${2-}" in
+    ""|-*) err "$1 requires a $3 argument"; exit 2 ;;
+  esac
+}
+
 while [ $# -gt 0 ]; do
   case "$1" in
     -h|--help) usage; exit 0 ;;
     --ilib-version)
-      [ $# -ge 2 ] || { err "$1 requires a version argument"; exit 2; }
-      ILIB_VERSION="$2"; shift 2 ;;
+      require_value "$1" "${2-}" "version"
+      ILIB_VERSION="$2"; ILIB_VERSION_SET=1; shift 2 ;;
+    --ilib-path)
+      require_value "$1" "${2-}" "directory"
+      ILIB_PATH_ARG="$2"; shift 2 ;;
     -o|--out-dir)
-      [ $# -ge 2 ] || { err "$1 requires a directory argument"; exit 2; }
+      require_value "$1" "${2-}" "directory"
       DEST_ROOT="$2"; shift 2 ;;
     --dry-run) DRY_RUN=1; shift ;;
     --keep-build) KEEP_BUILD=1; shift ;;
@@ -127,11 +145,28 @@ JSON
 fi
 
 # --- 2. install ilib + ilib-assemble ---------------------------------------
-log "Installing ilib@${ILIB_VERSION} and ilib-assemble@${ILIB_ASSEMBLE_VERSION}..."
-(cd "$BUILD_DIR" && npm install --no-audit --no-fund \
-  "ilib@${ILIB_VERSION}" "ilib-assemble@${ILIB_ASSEMBLE_VERSION}")
+# ilib-assemble is always installed into build/. ilib is downloaded too unless
+# --ilib-path points at an existing install to use as-is.
+if [ -n "$ILIB_PATH_ARG" ]; then
+  # Resolve to an absolute path so the assembler can be run from anywhere.
+  ILIB_PATH="$(cd "$ILIB_PATH_ARG" 2>/dev/null && pwd)" \
+    || { err "--ilib-path directory does not exist: $ILIB_PATH_ARG"; exit 1; }
+  [ -f "$ILIB_PATH/package.json" ] \
+    || { err "--ilib-path is not an ilib package (no package.json): $ILIB_PATH"; exit 1; }
+  if [ "$ILIB_VERSION_SET" = "1" ]; then
+    log "Note: --ilib-version is ignored because --ilib-path was given."
+  fi
+  log "Using existing ilib at: $ILIB_PATH"
+  log "Installing ilib-assemble@${ILIB_ASSEMBLE_VERSION}..."
+  (cd "$BUILD_DIR" && npm install --no-audit --no-fund \
+    "ilib-assemble@${ILIB_ASSEMBLE_VERSION}")
+else
+  log "Installing ilib@${ILIB_VERSION} and ilib-assemble@${ILIB_ASSEMBLE_VERSION}..."
+  (cd "$BUILD_DIR" && npm install --no-audit --no-fund \
+    "ilib@${ILIB_VERSION}" "ilib-assemble@${ILIB_ASSEMBLE_VERSION}")
+  ILIB_PATH="$BUILD_DIR/node_modules/ilib"
+fi
 
-ILIB_PATH="$BUILD_DIR/node_modules/ilib"
 ASSEMBLE_BIN="$BUILD_DIR/node_modules/.bin/ilib-assemble"
 [ -d "$ILIB_PATH" ]    || { err "ilib package not found at $ILIB_PATH"; exit 1; }
 [ -x "$ASSEMBLE_BIN" ] || { err "ilib-assemble binary not found at $ASSEMBLE_BIN"; exit 1; }


### PR DESCRIPTION
### Checklist

The following lists affects Pub Points on pub.dev when the package is published.
* [ ] Passed the all tests.
* [ ] Verified that the example app works.
* [ ] Executed the `dart format` command.
* [ ] Added the API description is added if necessary.

### Summary
Adds a reproducible script to assemble the iLib JavaScript that `flutter_ilib` ships under `assets/`, and speeds up the local test runner. Previously these assets had to be produced by hand with no documented, repeatable process.

### What's included
- **`scripts/assemble_ilib/generate_assets.sh`** — downloads `ilib` + `ilib-assemble` and builds:
  - `assets/js/ilib-init.js` — the assembled, minified iLib JS runtime
  - `assets/locales/<lang>.js` — per-language CLDR/locale data bundles
- **`scripts/assemble_ilib/README.md`** — usage, inputs, and options
- **`scripts/assemble_ilib/.gitignore`** — ignores the throwaway `build/`
- **`execute_unit_test.sh`** — resolve dependencies once instead of on every test

### How it works
- Driven by the existing inputs `ilib-inc.js` (legacy `!depends` module list) and `locales.json` (locale set).
- Installs into a throwaway `build/` dir, so **no global npm install** is required and the source tree stays clean.
- Uses `ilib-assemble --legacyilib`; the older "minified-source" patch is no longer needed with the current `ilib-assemble`.

### Options
| Option | Effect |
| --- | --- |
| `--ilib-version VER` | Pin the `ilib` npm version (default: latest) |
| `--ilib-path DIR` | Use an existing ilib install instead of downloading (overrides `--ilib-version`) |
| `-o, --out-dir DIR` | Write output to `DIR` instead of `assets/` |
| `--dry-run` | Write to a temp dir; leave `assets/` untouched |
| `--keep-build` | Keep `build/` for inspection |

Value-taking options reject a missing value or a value that is itself another flag (e.g. `--ilib-path --dry-run`) with a clear error.

### Test runner change (minor)
`flutter test` implicitly runs `pub get` on every invocation; with 114 test files this re-resolved dependencies 114 times (repeatedly printing "Downloading packages…"). Now `pub get` runs once up front — once for the root package and once for `example/` (which has its own pubspec for the widget integration tests) — and each `flutter test` uses `--no-pub`.

### Verification
- Ran the full assembly against the real `locales.json`: **66 locale bundles assembled byte-identical** to the current assets; `ilib-init.js` differs only by re-minification.
- Verified `--dry-run` / `--out-dir` leave `assets/` untouched.
- Verified `--ilib-path` skips the ilib download and that argument validation rejects missing/flag-shaped values.
- Confirmed the test runner no longer re-downloads packages per file (root and `example/`) and tests still pass.

