### PR TITLE
[migration/ilib-js-to-dart] Update code and docs: simplify JulianDay, implement getAvailableLocales, revise docs/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ pure-calculation classes need no locale loading (see Conventions › Testing).
 - `ilib.data.localeinfo` — locale metadata (clock, calendar, timezone, digits, etc.)
 - `ilib.data.localeinfo.numfmt` — number format patterns (nested under localeinfo)
 - `ilib.data.plurals` — CLDR plural rule tree (used by `ILibDurationFmt` plural selection)
-- `ilib.data.scriptinfo` — script metadata
+- `ilib.data.scripts` — script metadata
 - `ilib.data.sysres` — translated strings (month/day names, AM/PM, etc.)
 - `ilib.data.zoneinfo` — timezone + DST rules
 
@@ -135,7 +135,7 @@ lib/
 │   └── persian_algo_cal.dart   # + persian_algo_date.dart + persian_algo_rata_die.dart (algorithmic)
 └── internal/
     ├── ilib_utils.dart         # getLocale(), getJSONDataPaths(), etc.
-    ├── ilib_plural.dart        # getPluralCategory() — CLDR plural-rule eval (used by ILibDurationFmt)
+    ├── plural_utils.dart       # getPluralCategory() — CLDR plural-rule eval (used by ILibDurationFmt)
     ├── math_utils.dart         # rounding helpers (used by ILibNumFmt)
     └── logger/                 # internal logging (LogAdapter + package:logging); not part of the conversion
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ point-in-time/public spots listed below).
 - **iLib JS source**: **v14.22.0** — all `lib/` Dart code and `test/` cases were converted
   from the iLib JS at this tag (`js/lib/` and `js/test/` of github.com/iLib-js/iLib;
   `git checkout v14.22.0`).
-- **CLDR data**: **48.2** — the bundled `assets/locale/` JSON (218 locales) was generated from
+- **CLDR data**: **48.2** — the bundled `assets/locale/` JSON (144 locales) was generated from
   iLib v14.22.0, which incorporates CLDR 46.
 - When updating to a newer iLib/CLDR: bump the JS source and the generated locale data
   **together** (a JS-only or data-only bump will diverge), then re-run the converted tests
@@ -183,7 +183,7 @@ lib/
   cases to the JS-mirrored file (see docs/conversion-guide.md, docs/test-mapping.md)
 - **Do NOT convert JS tests for a locale that flutter_ilib does not support.** The authoritative
   list of supported locales is `scripts/assemble_ilib/locales.json` (the seed used to generate
-  `assets/locale/` — the 218 bundled iLib locales, see Source Versions); a per-locale test is in
+  `assets/locale/` — the 144 bundled iLib locales, see Source Versions); a per-locale test is in
   scope only if its locale is in that list. When the data is fully absent,
   `ILibLocaleInfo`/`ILibTimeZone.fromLocale` fall back to defaults (e.g. `Etc/UTC`), so the
   test cannot reproduce the JS expected value — these are N/A.

--- a/README.md
+++ b/README.md
@@ -184,6 +184,63 @@ fmt.format(-1234567.89);
 // '-$1,234,567.89'
 ```
 
+### Calendar Date
+
+```dart
+// Gregorian
+final ILibDateOptions date = ILibDateOptions(
+    year: 2024, month: 6, day: 27, hour: 13, minute: 45);
+date.getYears();   // 2024
+date.getMonths();  // 6
+date.getDays();    // 27
+date.getDayOfWeek(); // 4 (Thursday)
+date.getCalendar();  // 'gregorian'
+```
+
+### Calendar Meta
+
+```dart
+// Thai Solar (year = Gregorian + 543)
+final ILibCalendar cal = ThaiSolarCal();
+cal.getNumMonths(2567);     // 12
+cal.getMonLength(2, 2555);  // 29 (leap year)
+cal.isLeapYear(2555);       // true
+cal.isLeapYear(2554);       // false
+```
+
+### Calendar Formatting
+
+```dart
+// Persian calendar (fa-IR)
+final ILibDateFmtOptions fmtOptions = ILibDateFmtOptions(
+    locale: 'fa-IR',
+    length: 'long',
+    useNative: false);
+final ILibDateFmt fmt = ILibDateFmt(fmtOptions);
+final ILibDateOptions dateOptions = ILibDateOptions(
+    locale: 'fa-IR',
+    year: 1392,
+    month: 9,
+    day: 21);
+fmt.format(dateOptions);
+// '‏21 آذر 1392'
+```
+
+```dart
+// Ethiopic calendar (am-ET)
+final ILibDateFmtOptions fmtOptions = ILibDateFmtOptions(
+    locale: 'am-ET',
+    length: 'medium');
+final ILibDateFmt fmt = ILibDateFmt(fmtOptions);
+final ILibDateOptions dateOptions = ILibDateOptions(
+    locale: 'am-ET',
+    year: 2011,
+    month: 9,
+    day: 29);
+fmt.format(dateOptions);
+// '29 ግንቦት 2011'
+```
+
 ## ScriptInfo
 ```dart
 final ILibLocaleInfo locInfo = ILibLocaleInfo('en-US');
@@ -215,60 +272,6 @@ ctry.getName('TR');
 ctry.getCode('튀르키예');
 // 'TR'
 ```
-
-## CLASS
-
-### FlutterILib
-We provide some classes that can be easily used in a Flutter app.   
-Currently, we have the following classes:
-- `ILibCaseMapper`
-- `ILibCountry`
-- `ILibDateFmt`
-- `ILibDateOptions`
-- `ILibDurationFmt`
-- `ILibLocale`
-- `ILibLocaleInfo`
-- `ILibNumFmt`
-- `ILibScriptInfo`
-
-We have a plan to provide more classes and methods.  
-
-### ILibDateFmt
-- Class: [ILibDateFmtOptions](./Docs.md/#ilibdatefmtoptions)
-- Class: [ILibDateFmt](./Docs.md#ilibdatefmt)
-   - Methods: `format()`, `getClock()`, `getTemplate()`, `getMeridiemsRange()`
-
-### ILibDurationFmt
-- Class: [ILibDurationFmtOptions](./Docs.md/#ilibdurationfmtoptions)
-- Class: [ILibDurationFmt](./Docs.md/#ilibdurationfmt)
-   - Methods:  `format()`, `getLocale()`, `getStyle()`, `getLength()`
-
-### ILibDateOptions
-- Class: [ILibDateOptions](./Docs.md/#ilibdateoptions)
-
-### ILibLocale
-- Class: [ILibLocale](./Docs.md/#iliblocale)
-
-### ILibLocaleInfo
-- Class: [ILibLocaleInfo](./Docs.md/#iliblocaleinfo)
-  - Methods: `getLanguageName()`, `getRegionName()`, `getClock()`, `getLocale()`, `getUnits()`, `getCalendar()`, `getFirstDayOfWeek()`, `getWeekEndStart()`, `getWeekEndEnd()`, `getTimeZone()`, `getDecimalSeparator()`, `getNativeDecimalSeparator()`, `getGroupingSeparator()`, `getNativeGroupingSeparator()`, `getPrimaryGroupingDigits()`, `getSecondaryGroupingDigits()`, `getPercentageFormat()`, `getNegativePercentageFormat()`, `getPercentageSymbol()`, `getExponential()`, `getNativeExponential()`, `getNativePercentageSymbol()`, `getNegativeNumberFormat()`, `getCurrencyFormats()`, `getCurrency()`, `getDigitsStyle()`, `getDigits()`, `getNativeDigits()`, `getRoundingMode()`, `getScript()`, `getDefaultScript()`, `getAllScripts()`, `getMeridiemsStyle()`, `getPaperSize()`, `getDelimiterQuotationStart()`, `getDelimiterQuotationEnd()`
-
-### ILibNumFmt
-- Clasee: [ILibNumFmtOptions](./Docs.md/#ilibnumfmtoptions)
-- Class: [ILibNumFmt](./Docs.md/#ilibnumfmt)
-   - Methods:  `format()`, `constrain()`, `getLocale()`, `getStyle()`, `getType()`, `isGroupingUsed()`, `getMaxFractionDigits()`, `getMinFractionDigits()`, `getSignificantDigits()`, `getCurrency()`, `getRoundingMode()`, `getUseNative()`
-
-### ILibScriptInfo
-- Class: [ILibScriptInfo](./Docs.md/#ilibscriptinfo)
-   - Methods: `getCode()`, `getCodeNumber()`, `getName()`, `getLongCode()`, `getScriptDirection()`, `getNeedsIME()`, `getCasing()`
-
-### ILibCaseMapper
-- Class: [ILibCaseMapper](./Docs.md/#ilibcasemapper)
-  - Methods: `getLocale()`, `map()`
-
-### ILibCountry
-- Class: [ILibCountry](./Docs.md/#ilibcountry)
-  - Methods: `getAvailableCode()`, `getAvailableCountry()`, `getCode()`, `getName()`, `getLocale()`
 
 ## Supported Locales
 The results of the following locales are checked by unit tests.  

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,15 +1,13 @@
 ---
 title: flutter_ilib Documentation Index
-description: Complete documentation index and navigation guide for flutter_ilib
+description: Documentation index and navigation guide for flutter_ilib
 keywords: [index, navigation, documentation, guide]
 version: 2.0.0
 ---
 
 # flutter_ilib Documentation Index
 
-Welcome to flutter_ilib documentation. This index helps you find the right document for your needs.
-
-## 🤖 For AI Agents (Recommended Path)
+## For AI Agents (Recommended Path)
 
 If you're an AI agent (Claude, Copilot, etc.), follow this sequence:
 
@@ -18,65 +16,51 @@ If you're an AI agent (Claude, Copilot, etc.), follow this sequence:
    - Conversion status and source versions (the iLib / CLDR baseline — single source of truth)
    - Links into the detailed `docs/` below
 
-1. **[quick_reference.md](./quick_reference.md)** (Start here for an overview!)
+1. **[quick_reference.md](./quick_reference.md)** (Start here for an overview)
    - Quick facts and overview
    - Key classes and common usage
    - Commands reference
-   - Time: ~5 minutes
 
-2. **[architecture.md](./architecture.md)** (Deep dive)
-   - System architecture and design
-   - Data loading flow with diagrams
-   - Component details
-   - Validation logic
-   - Time: ~15 minutes
+2. **[architecture.md](./architecture.md)** (System design)
+   - System architecture and data loading flow
+   - Locale path generation and deep merge strategy
+   - Directory structure
 
 3. **[api.md](./api.md)** (APIs)
-   - Complete API reference
-   - All classes and methods
-   - Code examples for each API
-   - Type definitions
-   - Time: ~20 minutes
+   - Class overview and relationships
+   - Usage flows and combined examples
+   - For individual method signatures, see dartdoc comments in source
 
 4. **[development.md](./development.md)** (For developers)
    - Setup and environment
    - Testing guide
-   - Coding conventions
-   - Contributing guidelines
-   - Time: ~30 minutes
+   - Coding conventions and contribution guidelines
 
-## 📚 For Humans (Browse by Topic)
+---
 
-### I want to...
+## Browse by Topic
 
-#### Understand the project
+### Understand the project
 → [quick_reference.md](./quick_reference.md) + [architecture.md](./architecture.md)
 
-#### Use the library in my app
+### Use the library in my app
 → [quick_reference.md](./quick_reference.md) + [api.md](./api.md)
 
-#### Format dates by locale
-→ [api.md](./api.md#ilibdate-api) → "ILibDate API"
-
-#### Get locale information
-→ [api.md](./api.md#iliblocaleinfo-api) → "ILibLocaleInfo API"
-
-#### Parse locale strings
-→ [api.md](./api.md#iliblocale-api) → "ILibLocale API"
-
-#### Add new locale data
+### Add new locale data
 → [development.md](./development.md) → "Adding Locale Data"
 
-#### Contribute code
+### Contribute code
 → [development.md](./development.md) → "Git Workflow" + "Code Conventions"
 
-#### Understand data loading
+### Understand data loading
 → [architecture.md](./architecture.md) → "Data Loading Flow"
 
-#### Debug locale issues
+### Debug locale issues
 → [development.md](./development.md) → "Troubleshooting"
 
-## 📖 Documents
+---
+
+## Documents
 
 ### Core Documentation
 
@@ -84,8 +68,8 @@ If you're an AI agent (Claude, Copilot, etc.), follow this sequence:
 |----------|---------|----------|
 | [../CLAUDE.md](../CLAUDE.md) | Project source of truth: goal, conventions, must-follow rules, conversion status | Developers, AI |
 | [quick_reference.md](./quick_reference.md) | Quick overview and common patterns | Everyone |
-| [architecture.md](./architecture.md) | System design and internals | Developers, AI |
-| [api.md](./api.md) | Complete API reference | Developers, AI |
+| [architecture.md](./architecture.md) | System design, data loading flow, directory structure | Developers, AI |
+| [api.md](./api.md) | Class overview, usage flows, and combined examples | Developers, AI |
 | [development.md](./development.md) | Setup, testing, contribution | Developers |
 | [calendar-conversion.md](./calendar-conversion.md) | Calendar conversion logic in DateFmt | Developers, AI |
 | [date-calendar-architecture.md](./date-calendar-architecture.md) | Date & calendar system layers, constructor pattern, critical rules | Developers, AI |
@@ -93,64 +77,30 @@ If you're an AI agent (Claude, Copilot, etc.), follow this sequence:
 | [local-timezone-support.md](./local-timezone-support.md) | System `'local'` timezone — implemented (Strategy A) + optional Strategy B | Developers, AI |
 | [conversion-guide.md](./conversion-guide.md) | General JS→Dart conversion checklist | Developers |
 | [test-mapping.md](./test-mapping.md) | JS→Dart test file mapping, not-converted patterns | Developers, AI |
-| [benchmark.md](./benchmark.md) | Performance & memory: v2.0 (pure Dart) vs v1.3.0 (JS interop) + empty-app baseline | Developers, AI |
-| [numfmt-conversion-plan.md](./numfmt-conversion-plan.md) | NumFmt & Currency implementation reference (rounding, precision, API differences) | Developers, AI | ~200 lines |
+| [benchmark.md](./benchmark.md) | Performance & memory: v2.0 (pure Dart) vs v1.3.0 (JS interop) | Developers, AI |
+| [numfmt-conversion-plan.md](./numfmt-conversion-plan.md) | NumFmt & Currency implementation reference (rounding, precision, API differences) | Developers, AI |
 | [durationfmt-conversion-plan.md](./durationfmt-conversion-plan.md) | DurationFmt implementation reference (plural engine, clock style, RTL) | Developers, AI |
 
 ### External Documentation
 
-| Document | Purpose | Link |
-|----------|---------|------|
-| **README.md** | User guide and quick start | `../README.md` |
-| **Docs.md** | Detailed user documentation | `../Docs.md` |
-| **Tips.md** | Tips and troubleshooting | `../Tips.md` |
-| **CHANGELOG.md** | Version history | `../CHANGELOG.md` |
+| Document | Purpose |
+|----------|---------|
+| [../README.md](../README.md) | User guide and quick start |
+| [../CHANGELOG.md](../CHANGELOG.md) | Version history |
 
-## 🎯 Learning Paths
+---
 
-### Path 1: Quick Start (15 min)
-1. [quick_reference.md](./quick_reference.md) - Overview
-2. [README.md](../README.md) - Getting started examples
-
-### Path 2: Deep Understanding (1 hour)
-1. [quick_reference.md](./quick_reference.md) - Overview
-2. [architecture.md](./architecture.md) - How it works
-3. [api.md](./api.md) - What you can do
-4. [development.md](./development.md) - How to extend
-
-### Path 3: Contributing (1.5 hours)
-1. [quick_reference.md](./quick_reference.md) - Overview
-2. [architecture.md](./architecture.md) - System design
-3. [api.md](./api.md) - Current APIs
-4. [development.md](./development.md) - Full development guide
-5. [Docs.md](../Docs.md) - User-facing documentation
-
-### Path 4: Troubleshooting (15 min)
-1. [Tips.md](../Tips.md) - Known issues and solutions
-2. [development.md](./development.md#troubleshooting) - Debug steps
-
-## 🔍 Quick Search
+## Quick Search
 
 ### By Topic
 
-**Locale Handling**
-- Parsing: [api.md#iliblocale-api](./api.md#iliblocale-api)
-- Validation: [architecture.md#validation-logic](./architecture.md#validation-logic)
-- Data paths: [architecture.md#locale-path-generation](./architecture.md#locale-path-generation)
-
 **Data Loading**
 - Overview: [architecture.md#data-loading-flow](./architecture.md#data-loading-flow)
-- Algorithm: [architecture.md#step-by-step-process](./architecture.md#step-by-step-process)
+- Path generation: [architecture.md#locale-path-generation](./architecture.md#locale-path-generation)
 - Merging: [architecture.md#deep-merge-strategy](./architecture.md#deep-merge-strategy)
 
 **Timezone**
-- System `'local'` support (implemented, Strategy A): [local-timezone-support.md](./local-timezone-support.md)
-
-**APIs**
-- ILibLocale: [api.md#iliblocale-api](./api.md#iliblocale-api)
-- ILibLocaleInfo: [api.md#iliblocaleinfo-api](./api.md#iliblocaleinfo-api)
-- ILibDate: [api.md#ilibdate-api](./api.md#ilibdate-api)
-- ILibCaseMapper: [api.md#ilibcasemapper-api](./api.md#ilibcasemapper-api)
+- System `'local'` support (Strategy A): [local-timezone-support.md](./local-timezone-support.md)
 
 **Development**
 - Setup: [development.md#initial-setup](./development.md#initial-setup)
@@ -158,120 +108,25 @@ If you're an AI agent (Claude, Copilot, etc.), follow this sequence:
 - Code Style: [development.md#code-conventions](./development.md#code-conventions)
 - Contributing: [development.md#git-workflow](./development.md#git-workflow)
 
-### By Audience
-
-**Product Managers / Non-Technical**
-- [quick_reference.md](./quick_reference.md) - Overview
-
-**App Developers (Using the library)**
-- [quick_reference.md](./quick_reference.md) - Overview
-- [api.md](./api.md) - How to use
-- [README.md](../README.md) - Examples
-
-**Library Developers (Contributing)**
-- [quick_reference.md](./quick_reference.md) - Overview
-- [architecture.md](./architecture.md) - How it works
-- [api.md](./api.md) - Current APIs
-- [development.md](./development.md) - Development guide
-
-**System Architects**
-- [architecture.md](./architecture.md) - Design
-- [api.md](./api.md) - Interface
-
-**QA / Testers**
-- [development.md#testing](./development.md#testing) - Test guide
-- [Tips.md](../Tips.md) - Known issues
-
-## 📋 Document Metadata
-
-### quick_reference.md
-- **Type**: Overview
-- **Difficulty**: Beginner
-- **Prerequisite**: None
-- **Topics**: Classes, Common patterns, Quick commands
-- **Best for**: Everyone, quick overview
-
-### architecture.md
-- **Type**: Deep dive
-- **Difficulty**: Intermediate
-- **Prerequisite**: quick_reference.md
-- **Topics**: System design, Data flow, Component details
-- **Best for**: Developers, system designers
-
-### api.md
-- **Type**: Reference
-- **Difficulty**: Intermediate
-- **Prerequisite**: quick_reference.md
-- **Topics**: All APIs, Methods, Examples
-- **Best for**: Developers, API usage
-
-### development.md
-- **Type**: Guide
-- **Difficulty**: Intermediate-Advanced
-- **Prerequisite**: quick_reference.md, architecture.md
-- **Topics**: Setup, Testing, Code style, Contributing
-- **Best for**: Contributors, maintainers
-
-## 🔗 Related Resources
-
-### Official
-- **iLib GitHub**: https://github.com/iLib-js/iLib
-- **BCP 47 Standard**: https://tools.ietf.org/html/bcp47
-- **ISO Standards**:
-  - ISO 639 (Languages): https://iso639-3.sil.org/
-  - ISO 3166 (Countries): https://www.iso.org/iso-3166-1-alpha-2.html
-  - ISO 15924 (Scripts): https://www.unicode.org/iso15924/
-
-### Flutter
-- **Flutter Docs**: https://flutter.dev/docs
-- **Dart Language**: https://dart.dev/guides
-- **Pub.dev Package**: https://pub.dev/packages/flutter_ilib
-
-## ❓ FAQ
-
-**Q: Where do I start?**  
-A: If you're an AI agent, follow the "For AI Agents" path above. If you're a human, choose a learning path based on your goal.
-
-**Q: What's the difference between quick_reference and api?**  
-A: `quick_reference` gives you the essentials and common patterns. `api` is the complete reference with all details.
-
-**Q: I want to understand how locale data is loaded.**  
-A: Read [architecture.md#data-loading-flow](./architecture.md#data-loading-flow).
-
-**Q: I want to add a new locale.**  
-A: Read [development.md#adding-locale-data](./development.md#adding-locale-data).
-
-**Q: I found a bug, what do I do?**  
-A: Check [Tips.md](../Tips.md) first, then file an issue on GitHub.
-
-**Q: How do I run tests?**  
-A: Read [development.md#running-tests](./development.md#running-tests).
-
-## 🎓 Knowledge Graph
-
-```
-quick_reference (Start Here!)
-    ↓
-architecture (Understand the system)
-    ↓
-api (Learn the APIs)
-    ↓
-development (Get hands-on)
-```
-
-## 📝 Document Status
-
-| Document | Status |
-|----------|--------|
-| quick_reference.md | ✅ Current |
-| architecture.md | ✅ Current |
-| api.md | ✅ Current |
-| development.md | ✅ Current |
-| README.md | ✅ Current |
-| CHANGELOG.md | ✅ Current |
-
 ---
 
-**Note**: This documentation is designed to be read by both humans and AI agents. Documents are self-contained but cross-referenced for completeness.
+## FAQ
+
+**Q: Where do I start?**
+A: If you're an AI agent, follow the "For AI Agents" path above. If you're a human, pick a topic from "Browse by Topic".
+
+**Q: What's the difference between quick_reference and api?**
+A: `quick_reference` gives you the essentials and common patterns. `api` covers class relationships, usage flows, and combined examples.
+
+**Q: How do I understand how locale data is loaded?**
+A: Read [architecture.md#data-loading-flow](./architecture.md#data-loading-flow).
+
+**Q: How do I add a new locale?**
+A: Read [development.md#adding-locale-data](./development.md#adding-locale-data).
+
+**Q: How do I run tests?**
+A: Read [development.md#running-tests](./development.md#running-tests).
+
+---
 
 *See CHANGELOG.md for version history.*

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,618 +1,192 @@
 ---
 title: flutter_ilib API Reference
-description: Complete API reference for flutter_ilib classes and methods
+description: Class overview, usage flows, and combined examples for flutter_ilib
 keywords: [flutter, ilib, api, reference, documentation]
 version: 2.0.0
 ---
 
 # flutter_ilib API Reference
 
+> For individual method signatures and parameters, see the dartdoc comments in
+> each source file. This document covers the class overview, how classes relate
+> to each other, and combined usage examples.
+
 ## Overview
 
 | Class | File | Purpose |
 |-------|------|---------|
-| `ILibLocale` | `lib/ilib_locale.dart` | Locale parsing & validation |
-| `ILibLocaleInfo` | `lib/ilib_localeinfo.dart` | Locale information lookup |
-| `ILibDate` / `ILibDateOptions` | `lib/ilib_date_accessor.dart`, `lib/ilib_date.dart` | Date object (calendar-aware accessors + instant) |
+| `ILibLocale` | `lib/ilib_locale.dart` | BCP-47 locale parsing & validation |
+| `ILibLocaleInfo` | `lib/ilib_localeinfo.dart` | Locale metadata (clock, calendar, currency, …) |
+| `ILibDate` / `ILibDateOptions` | `lib/ilib_date.dart` | Date object — calendar components + instant accessors |
 | `ILibDateFmt` | `lib/ilib_datefmt.dart` | Date/time formatting |
-| `ILibCalendar` | `lib/ilib_calendar.dart` + `lib/calendar/` | Calendar rules (months, leap year) & factory |
+| `ILibDurationFmt` | `lib/ilib_durationfmt.dart` | Duration formatting |
+| `ILibNumFmt` | `lib/ilib_numfmt.dart` | Number & currency formatting |
+| `ILibCalendar` | `lib/ilib_calendar.dart` + `lib/calendar/` | Calendar rules (month count, month length, leap year) |
 | `ILibTimeZone` | `lib/ilib_timezone.dart` | Timezone offset & DST calculation |
-| `ILibCaseMapper` | `lib/ilib_casemapper.dart` | Case conversion |
+| `ILibCaseMapper` | `lib/ilib_casemapper.dart` | Locale-aware case conversion |
+| `ILibScriptInfo` | `lib/ilib_scriptinfo.dart` | Script metadata (direction, IME, casing) |
+| `ILibCountry` | `lib/ilib_country.dart` | Country code ↔ name lookup |
+| `ILibCurrency` | `lib/ilib_currency.dart` | Currency metadata |
+| `ILibLoader` | `lib/ilib_init.dart` | Locale data loading & readiness |
 
 ---
 
-## ILibLocale API
+## Class Relationships & Usage Flows
 
-### Purpose
-Parse, validate, and manipulate locale strings according to BCP-47 standard.
+### 1. Locale → Locale Metadata
 
-### Constructors
+`ILibLocale` parses a BCP-47 string into components. `ILibLocaleInfo` takes a
+locale (string or `ILibLocale`) and returns regional conventions.
 
-```dart
-/// Parse from locale string
-final locale = ILibLocale('en-US');
-final locale = ILibLocale('zh-Hans-CN');
-final locale = ILibLocale('MK');  // Region-only
+```
+ILibLocale('ko-KR')
+  └─ .getLanguage()  → 'ko'
+  └─ .getRegion()    → 'KR'
 
-/// Construct from components
-final locale = ILibLocale('en', 'US');
-final locale = ILibLocale('zh', null, 'CN', 'Hans');
-final locale = ILibLocale(null, 'MK');  // Region-only
+ILibLocaleInfo('ko-KR')
+  └─ .getClock()          → '24'
+  └─ .getCalendar()       → 'gregorian'
+  └─ .getFirstDayOfWeek() → 0  (Sunday)
+  └─ .getCurrency()        → 'KRW'
+  └─ .getLocale()          → ILibLocale
 ```
 
-### Properties
+### 2. Date Object → Formatter
 
-```dart
-// Read-only
-locale.language      // String? → ISO 639 code (e.g., 'en', 'ko')
-locale.region        // String? → ISO 3166 code (e.g., 'US', 'KR')
-locale.script        // String? → ISO 15924 code (e.g., 'Hans', 'Arab')
-locale.variant       // String? → Variant identifier
-locale.spec          // String  → Full normalized spec (e.g., 'en-US')
+`ILibDateOptions` holds calendar components (or a Unix time / Flutter
+`DateTime`). `ILibDateFmt` formats it as a locale string. The two are always
+used together.
+
+```
+ILibDateOptions(year, month, day, …)   ← build the date
+  └─ ILibDateFmt(ILibDateFmtOptions(locale, length, …)).format(date)
+       └─ String result
 ```
 
-### Key Methods
+`ILibDateOptions` also exposes accessors (`getYears()`, `getMonths()`,
+`getDayOfWeek()`, `getCalendar()`, …) for reading back calendar components.
 
-```dart
-String? getLanguage()           // ISO 639 code
-String? getLanguageAlpha3()     // ISO 639-3 code (e.g., 'eng')
+The `calendar` / `type` field on `ILibDateOptions` selects which calendar system
+the components are interpreted in (`'gregorian'` by default; `fa-IR` defaults to
+`'persian'`, `am-ET` to `'ethiopic'`, etc.).
 
-String? getRegion()             // ISO 3166-2 code
-String? getRegionAlpha3()       // ISO 3166-3 code (e.g., 'USA')
+### 3. Calendar Rules
 
-String? getScript()             // ISO 15924 code
-String? getVariant()            // Variant
+`ILibCalendar` answers calendar-level questions independently of any date
+object — useful for building pickers or validating input.
 
-String getSpec()                // Normalized locale spec
-String getLangSpec()            // Language + script spec
+```
+ILibCalendar('gregorian')
+  └─ .isLeapYear(2024)        → true
+  └─ .getMonLength(2, 2024)   → 29
+  └─ .getNumMonths(2024)      → 12
 
-String toString()               // Same as getSpec()
-
-// Static utility methods
-static String? regionAlpha2ToAlpha3(String? alpha2)
-static String? languageAlpha1ToAlpha3(String? alpha1)
-
-// Static validation
-static bool _isLanguageCode(String? str)
-static bool _isRegionCode(String? str)
-static bool _isScriptCode(String? str)
+ILibCalendar.fromLocale('fa-IR')  → persian calendar
 ```
 
-### Examples
+### 4. Timezone
 
-```dart
-// Parsing
-final loc1 = ILibLocale('ko-KR');
-print(loc1.language);     // 'ko'
-print(loc1.region);       // 'KR'
-print(loc1.getSpec());    // 'ko-KR'
+`ILibTimeZone` provides raw offsets and DST rules. It is used directly or via
+`ILibDateFmt` (pass `timezone:` to `ILibDateFmtOptions`).
 
-// Script support
-final loc2 = ILibLocale('zh-Hans-CN');
-print(loc2.language);     // 'zh'
-print(loc2.script);       // 'Hans'
-print(loc2.region);       // 'CN'
-
-// Region-only (new in v2.0)
-final loc3 = ILibLocale('MK');
-print(loc3.language);     // null
-print(loc3.region);       // 'MK'
-print(loc3.getSpec());    // 'MK'
-
-// Code conversion
-final code = ILibLocale.languageAlpha1ToAlpha3('en');
-print(code);              // 'eng'
+```
+ILibTimeZone('America/New_York')
+  └─ .getRawOffsetStr()               → '-05:00'
+  └─ .inDaylightTime(date)            → true/false
+  └─ .getDisplayName(date)            → 'EST' / 'EDT'
+  └─ .getOffsetMinutes(date)          → effective offset incl. DST
 ```
 
----
+### 5. Number & Currency Formatting
 
-## ILibLocaleInfo API
+`ILibNumFmt` uses `ILibNumFmtOptions` and formats numbers according to locale
+conventions. Currency formatting requires the `type: 'currency'` option.
 
-### Purpose
-Retrieve locale-specific information (region name, timezone, currency, etc.).
-
-### Constructor
-
-```dart
-// Create with locale
-final info = ILibLocaleInfo('ko-KR');
-final info = ILibLocaleInfo('en-US');
-final info = ILibLocaleInfo('MK');  // Region-only
-final info = ILibLocaleInfo();      // Current system locale
+```
+ILibNumFmt(ILibNumFmtOptions(locale, type, currency, …)).format(number)
+  └─ String result  (e.g. '$1,234.56', '1.234,56 €')
 ```
 
-### Methods
+### 6. Duration Formatting
 
-#### Region & Language
+`ILibDurationFmt` formats a duration expressed as calendar components (years,
+months, weeks, days, hours, minutes, seconds). The `style: 'clock'` option
+renders hours/minutes as `HH:MM`.
 
-```dart
-String? getRegionName()      // e.g., 'South Korea', 'North Macedonia'
-String getLanguageName()     // e.g., 'Korean', 'English'
 ```
-
-#### Time
-
-```dart
-String getClock()            // '12' or '24'
-String getTimeZone()         // e.g., 'Asia/Seoul', 'America/New_York'
-int getFirstDayOfWeek()      // 0 (Sun) to 6 (Sat)
-int getWeekEndStart()        // 0 (Sun) to 6 (Sat)
-int getWeekEndEnd()          // 0 (Sun) to 6 (Sat)
-```
-
-#### Numbers & Formatting
-
-```dart
-String getDecimalSeparator()         // e.g., '.', ','
-String getNativeDecimalSeparator()   // Native script variant
-String getGroupingSeparator()        // e.g., ',', ' '
-String getNativeGroupingSeparator()  // Native script variant
-
-int getPrimaryGroupingDigits()       // e.g., 3 (millions)
-int getSecondaryGroupingDigits()     // e.g., 3 (further grouping)
-
-String getRoundingMode()             // 'halfup', 'halfdown', etc.
-String getNativeDigits()             // e.g., 'Western', 'Latin'
-```
-
-#### Calendars & Units
-
-```dart
-String getCalendar()         // e.g., 'gregorian', 'islamic'
-String getUnits()            // 'metric', 'imperial', etc.
-
-List<String>? getScripts()   // Scripts commonly used (e.g., ['Cyrl'])
-```
-
-#### Locale
-
-```dart
-ILibLocale getLocale()       // Return ILibLocale instance
-String? get locale           // Locale spec string
-```
-
-### Examples
-
-```dart
-final info = ILibLocaleInfo('ko-KR');
-
-// Region information
-print(info.getRegionName());        // 'South Korea'
-print(info.getLanguageName());      // 'Korean'
-
-// Time settings
-print(info.getClock());              // '24'
-print(info.getTimeZone());           // 'Asia/Seoul'
-print(info.getFirstDayOfWeek());     // 0 (Sunday)
-
-// Number formatting
-print(info.getDecimalSeparator());   // '.'
-print(info.getGroupingSeparator());  // ','
-
-// Calendar
-print(info.getCalendar());           // 'gregorian'
-print(info.getUnits());              // 'metric'
+ILibDurationFmt(ILibDurationFmtOptions(locale, length, style)).format(dateOptions)
+  └─ String result  (e.g. '1 year, 2 months', '01:30')
 ```
 
 ---
 
-## ILibDate & ILibDateFmt API
+## Combined Examples
 
-### Purpose
-`ILibDate` is the date interface (calendar-aware component accessors + the underlying instant);
-`ILibDateOptions` is its concrete implementation — construct a date from calendar components or a
-Unix time. `ILibDateFmt` formats an `ILibDate` according to locale conventions.
-
-> Note: `ILibDate` is an abstract interface — you do **not** construct it from a `DateTime`. Build a
-> date with `ILibDateOptions(...)` and format it with `ILibDateFmt(...).format(date)`.
-
-### Constructing a date — `ILibDateOptions`
+### Date formatting with timezone
 
 ```dart
-// From calendar components
-final date = ILibDateOptions(
-  year: 2011, month: 9, day: 29,
-  hour: 13, minute: 45, second: 0,
-  timezone: 'America/New_York',  // omitted ⇒ 'local' (system tz), unless a locale is set (its zone wins)
-  calendar: 'gregorian',         // omitted ⇒ locale default / gregorian
-  locale: 'en-US',
-);
-
-// From a Unix time in ms (e.g. a Flutter DateTime)
-final date2 = ILibDateOptions(unixtime: DateTime(2011, 9, 29).millisecondsSinceEpoch);
+final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+    locale: 'ko-KR',
+    length: 'full',
+    type: 'datetime',
+    useNative: false,
+    timezone: 'Asia/Seoul'));
+fmt.format(ILibDateOptions(
+    year: 2024, month: 6, day: 27, hour: 10, minute: 42));
+// '2024년 6월 27일 오전 10:42'
 ```
 
-`ILibDateOptions(...)` parameters: `locale`, `year`, `month`, `week`, `day`, `hour`, `minute`,
-`second`, `millisecond`, `unixtime`, `timezone`, `calendar`, `dateTime`, `type`, `dst`.
-
-### `ILibDate` accessors (implemented by `ILibDateOptions`)
+### Non-Gregorian calendar formatting
 
 ```dart
-int? get year / month / day / hour / minute / second / millisecond
-String? get timezone        // or getTimeZone()
-bool?   get dst             // DST-overlap disambiguation (null = unspecified)
+// Persian calendar — fa-IR defaults to 'persian'
+ILibDateFmt(ILibDateFmtOptions(locale: 'fa-IR', length: 'long', useNative: false))
+    .format(ILibDateOptions(locale: 'fa-IR', year: 1392, month: 9, day: 21));
+// '‏21 آذر 1392'
 
-int getDayOfWeek()          // 0=Sun .. 6=Sat
-int getWeekOfYear()         // ISO 8601 week
-int getDayOfYear()          // 1..366
-int getWeekOfMonth(String? locale)
-int getEra()                // 0=BCE, 1=CE
-
-// Underlying instant (mirrors JS IDate)
-double getRataDie()
-double getJulianDay()
-int    getTime()            // ms since Unix epoch
-int    getTimeExtended()
-String getCalendar()
+// Ethiopic calendar — am-ET defaults to 'ethiopic'
+ILibDateFmt(ILibDateFmtOptions(locale: 'am-ET', length: 'medium'))
+    .format(ILibDateOptions(locale: 'am-ET', year: 2011, month: 9, day: 29));
+// '29 ግንቦት 2011'
 ```
 
-### Formatting — `ILibDateFmt`
+### Locale metadata → number formatting
 
 ```dart
-final fmt = ILibDateFmt(ILibDateFmtOptions(
-  locale: 'en-US',
-  length: 'short',      // 'short' | 'medium' | 'long' | 'full'
-  type: 'date',         // 'date' | 'time' | 'datetime'
-));
-String out = fmt.format(date);   // ILibDate → String
+final ILibLocaleInfo info = ILibLocaleInfo('de-DE');
+// info.getDecimalSeparator()  → ','
+// info.getGroupingSeparator() → '.'
 
-// Other methods
-int    getClock();                  // 12 or 24
-String getTemplate();               // the resolved format template
-String getDateComponentOrder();     // e.g. '{date} {time}'
-List<MeridiemsInfo> getMeridiemsRange();
+ILibNumFmt(ILibNumFmtOptions(locale: 'de-DE')).format(1234567.89);
+// '1.234.567,89'
 ```
 
-`ILibDateFmtOptions(...)` parameters: `locale`, `length`, `type`, `calendar`, `timezone`,
-`useNative`, `date`, `time`, `clock`, `template`, `meridiems`.
-
-### Examples
+### Country code lookup
 
 ```dart
-final date = ILibDateOptions(year: 2011, month: 9, day: 29);
-
-// Short date
-print(ILibDateFmt(ILibDateFmtOptions(length: 'short')).format(date));   // '9/29/11'
-
-// Long date
-print(ILibDateFmt(ILibDateFmtOptions(locale: 'en-US', length: 'long')).format(date));
-// 'September 29, 2011'
-
-// Time only
-final t = ILibDateOptions(year: 2011, month: 9, day: 29, hour: 13, minute: 45);
-print(ILibDateFmt(ILibDateFmtOptions(length: 'short', type: 'time')).format(t));  // '1:45 PM'
+final ILibCountry ctry = ILibCountry(locale: 'ko-KR');
+ctry.getName('TR');   // '튀르키예'
+ctry.getCode('튀르키예');  // 'TR'
 ```
 
 ---
 
-## ILibCaseMapper API
-
-### Purpose
-Perform locale-aware case conversion.
-
-### Constructor
-
-```dart
-final mapper = ILibCaseMapper('tr-TR');  // Turkish
-final mapper = ILibCaseMapper('en-US');  // English (US)
-final mapper = ILibCaseMapper();         // Current locale
-```
-
-### Key Methods
-
-```dart
-String toLowerCase(String str)    // Locale-aware lowercase
-String toUpperCase(String str)    // Locale-aware uppercase
-String toLocaleCase(String str)   // Mixed case per locale
-```
-
-### Examples
-
-```dart
-// Standard case conversion
-final mapper1 = ILibCaseMapper('en-US');
-print(mapper1.toLowerCase('HELLO'));      // 'hello'
-print(mapper1.toUpperCase('hello'));      // 'HELLO'
-
-// Locale-specific handling
-final mapper2 = ILibCaseMapper('tr-TR');  // Turkish
-print(mapper2.toLowerCase('İ'));          // 'i̇' (Turkish dotless-i)
-print(mapper2.toUpperCase('i'));          // 'İ' (Turkish dotted-I)
-
-// German ß handling
-final mapper3 = ILibCaseMapper('de-DE');
-print(mapper3.toUpperCase('straße'));     // 'STRASSE' (German-specific)
-```
-
----
-
-## ILibCalendar API
-
-### Purpose
-Calendar rules — month count, month length, and leap-year — plus the calendar factory. (Date
-*objects* are built with `ILibDateOptions`; this class answers calendar-level questions.)
-
-### Construction
-
-```dart
-final cal = ILibCalendar();                    // default: gregorian
-final cal = ILibCalendar('islamic');           // by type
-final cal = ILibCalendar.fromLocale('ar-SA');  // calendar used by the locale
-```
-
-Supported types: `gregorian`, `thaisolar`, `julian`, `islamic`, `persian` (astronomical),
-`persian-algo` (algorithmic), `ethiopic`, `coptic`, `hebrew`.
-(`'han'` throws `UnimplementedError`; an unknown type throws `ArgumentError`.)
-
-### Methods
-
-```dart
-String getType()                          // e.g. 'gregorian'
-int    getNumMonths(int year)             // months in the given year
-int    getMonLength(int month, int year)  // days in month (1-based month)
-bool   isLeapYear(int year)
-
-static List<String> getCalendars()        // all supported type names
-```
-
-### Examples
-
-```dart
-final greg = ILibCalendar('gregorian');
-print(greg.getMonLength(2, 2012));   // 29 (leap year)
-print(greg.isLeapYear(2011));        // false
-
-final hijri = ILibCalendar('islamic');
-print(hijri.getNumMonths(1432));     // 12
-```
-
----
-
-## ILibTimeZone API
-
-### Purpose
-Timezone offset and DST calculation from the bundled `zoneinfo` data. `'local'` resolves to the
-DST-aware system timezone (see [local-timezone-support.md](./local-timezone-support.md)).
-
-### Constructors
-
-```dart
-final tz = ILibTimeZone('America/New_York');
-final tz = ILibTimeZone('local');              // system timezone
-final tz = ILibTimeZone.fromOffset(-480);      // fixed offset in minutes
-final tz = ILibTimeZone.fromLocale('ko-KR');   // 'Asia/Seoul'
-final tz = ILibTimeZone.defaultZone();         // current system locale's zone
-```
-
-### Methods
-
-```dart
-String getId()                      // e.g. 'America/New_York' ('local' stays 'local')
-
-// Standard (raw) offset — excludes DST
-Map<String,int> getRawOffset()      // {'h': -8, 'm': 0}
-double getRawOffsetMinutes()
-String getRawOffsetStr()            // e.g. '-08:00'
-int    getRawOffsetMillis()
-
-// DST
-bool   useDaylightTime()
-Map<String,int> getDSTSavings()
-double getDSTSavingsMinutes()
-String getDSTSavingsStr()
-bool   inDaylightTime(ILibDate date, {bool wallTime = false})
-
-// Effective offset for a date (includes DST when applicable)
-double getOffsetMinutes(ILibDate date, {bool wallTime = false})
-int    getOffsetMillis(ILibDate date)
-
-// Display name: default → abbreviation ('PST'/'PDT'); 'long' → full name; 'rfc822' → offset
-String getDisplayName(ILibDate date, [String style = ''])
-
-static List<String> getAvailableIds([String? country])
-```
-
-### Examples
-
-```dart
-final tz = ILibTimeZone('America/Los_Angeles');
-print(tz.getId());                // 'America/Los_Angeles'
-print(tz.getRawOffsetStr());      // '-08:00'
-print(tz.useDaylightTime());      // true
-
-final summer = ILibDateOptions(
-  year: 2011, month: 7, day: 1, timezone: 'America/Los_Angeles');
-print(tz.inDaylightTime(summer));              // true
-print(tz.getDisplayName(summer));              // 'PDT'
-print(tz.getDisplayName(summer, 'rfc822'));    // 'UTC-0700' (DST)
-```
-
----
-
-## ILibLoader (Internal) API
-
-### Purpose
-Manage locale data loading and caching.
-
-### Access
-
-```dart
-// Global singleton
-final loader = ILibLoader.instance;
-
-// Check readiness
-if (loader.isILibReady) {
-  // Safe to use
-}
-```
-
-### Key Methods
-
-```dart
-/// Get cached locale data
-Map<String, dynamic>? getLocaleData(String locale)
-
-/// Load current locale data and notify listeners
-Future<void> loadJSON()
-
-/// Mark as prepared (validates data is loaded)
-void initILib()
-
-/// Load additional locale data
-Future<void> loadILibLocaleData(String? locale)
-
-/// Load all supported locales
-Future<void> loadILibLocaleDataAll()
-
-/// Listen for readiness
-void addListener(VoidCallback callback)
-void removeListener(VoidCallback callback)
-```
-
-### Examples
-
-```dart
-final loader = ILibLoader.instance;
-
-// Listen for initialization
-loader.addListener(() {
-  print('iLib is ready!');
-  // Now safe to use ILibLocaleInfo, etc.
-});
-
-// Check if ready
-if (loader.isILibReady) {
-  final info = ILibLocaleInfo('en-US');
-  print(info.getRegionName());
-}
-```
-
----
-
-## Global Utilities
-
-### ilib_utils Functions
-
-```dart
-/// Get paths for loading locale data
-List<String> getJSONDataPaths(String? locale)
-
-/// Get single path for locale
-String getJSONDataPath(String? locale)
-
-/// Validate locale format
-bool isValidLocale(String lo)
-
-/// Get all supported locales
-List<String> getSupportedLocales()
-
-/// Get/set current system locale
-String getLocale()
-void setLocale(String loc)
-```
-
-### Examples
-
-```dart
-import 'package:flutter_ilib/internal/ilib_utils.dart';
-
-// Check if locale is valid
-if (isValidLocale('ko-KR')) {
-  print('Valid!');
-}
-
-// Get load paths
-final paths = getJSONDataPaths('en-US');
-// ['root.json', 'en.json', 'und-US.json', 'en-US.json']
-
-// Get all supported locales
-final all = getSupportedLocales();
-// ['af-ZA', 'en-US', 'ko-KR', ...]
-
-// Manage system locale
-final current = getLocale();  // 'en-US'
-setLocale('ko-KR');
-```
-
----
-
-## Type Definitions
-
-### ILibDateFmtOptions
-
-```dart
-class ILibDateFmtOptions {
-  String? locale;        // BCP-47 locale code
-  String? length;        // 'short' | 'medium' | 'long' | 'full'
-  String? type;          // 'date' | 'time' | 'datetime'
-  String? calendar;      // e.g. 'gregorian', 'islamic'
-  String? timezone;      // e.g. 'Etc/UTC', 'local'
-  String? date;          // date-component subset (e.g. 'dmy', 'dm')
-  String? time;          // time-component subset (e.g. 'ahm', 'hms')
-  String? clock;         // '12' or '24'
-  String? template;      // custom format template
-  String? meridiems;     // meridiems style
-  bool?   useNative;     // use native numerals?
-}
-```
-
----
-
-## Error Handling
-
-### Common Issues & Solutions
-
-```dart
-// Issue: getRegionName() returns null
-if (info.getRegionName() == null) {
-  // Locale data not loaded yet - wait for ILibLoader.isILibReady
-}
-
-// Issue: Locale not recognized
-if (!isValidLocale(userInput)) {
-  // Use default locale instead
-  final info = ILibLocaleInfo('en-US');
-}
-
-// Issue: Date formatting produces unexpected output
-// Ensure locale is loaded before formatting
-if (ILibLoader.instance.isILibReady) {
-  final date = ILibDateOptions(year: 2026, month: 5, day: 6, timezone: 'Etc/UTC');
-  print(ILibDateFmt(ILibDateFmtOptions(locale: 'en-US', length: 'short')).format(date));
-}
-```
-
----
-
-## Export & Imports
-
-### Full Public API
+## Public API
 
 ```dart
 import 'package:flutter_ilib/flutter_ilib.dart';
 
-// Now available:
-// - ILibLocale
-// - ILibLocaleInfo
+// Available classes:
+// - FlutterILib, ILibLoader
+// - ILibLocale, ILibLocaleInfo
 // - ILibDate / ILibDateOptions
 // - ILibDateFmt (+ ILibDateFmtOptions, MeridiemsInfo)
-// - ILibCalendar (+ per-calendar date classes: GregorianDate, IslamicDate, ...)
+// - ILibDurationFmt (+ ILibDurationFmtOptions)
+// - ILibNumFmt (+ ILibNumFmtOptions)
+// - ILibCalendar (+ per-calendar classes: GregorianDate, ThaiSolarDate, …)
 // - ILibTimeZone
 // - ILibCaseMapper
-// - ILibLoader
-```
-
-### Internal Utilities
-
-```dart
-import 'package:flutter_ilib/internal/ilib_utils.dart';
-
-// Now available:
-// - isValidLocale()
-// - getJSONDataPaths()
-// - getLocale()
-// - setLocale()
-// - getSupportedLocales()
+// - ILibScriptInfo, ILibCountry, ILibCurrency
 ```
 
 ---

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 ---
 title: flutter_ilib Architecture
-description: Detailed architecture, design patterns, and data flow for flutter_ilib
+description: System architecture, data flow, and design patterns for flutter_ilib
 keywords: [flutter, ilib, architecture, design, locale-data]
 version: 2.0.0
 ---
@@ -16,12 +16,16 @@ flutter_ilib (Dart/Flutter Plugin)
     ├── Public API (lib/*.dart, exported from flutter_ilib.dart)
     │   ├── ILibLocale
     │   ├── ILibLocaleInfo
-    │   ├── ILibCaseMapper
     │   ├── ILibDate / ILibDateOptions
     │   ├── ILibDateFmt
+    │   ├── ILibDurationFmt
+    │   ├── ILibNumFmt
     │   ├── ILibCalendar (+ lib/calendar/: 9 calendars, Rata Die, Astro)
     │   ├── ILibTimeZone
-    │   ├── ILibDurationFmt
+    │   ├── ILibCaseMapper
+    │   ├── ILibScriptInfo
+    │   ├── ILibCountry
+    │   ├── ILibCurrency
     │   └── ILibLoader (data loading)
     │
     ├── Internal (lib/internal/)
@@ -38,6 +42,8 @@ flutter_ilib (Dart/Flutter Plugin)
             ├── {language}-{region}.json
             └── {language}-{script}-{region}.json   (e.g. zh-Hans-CN)
 ```
+
+---
 
 ## Data Loading Flow
 
@@ -58,7 +64,7 @@ flutter_ilib (Dart/Flutter Plugin)
    ↓
 7. Cache merged result in ILibLoader._localeDataMap
    ↓
-8. API calls access merged data (ILibLocaleInfo, ILibDate, etc.)
+8. API calls access merged data (ILibLocaleInfo, ILibDateFmt, etc.)
 ```
 
 ### Locale Path Generation
@@ -88,7 +94,7 @@ Output: Array of file paths in priority order
 |-------|--------------|
 | `"ko"` | `[root.json, ko.json]` |
 | `"en-US"` | `[root.json, en.json, und-US.json, en-US.json]` |
-| `"MK"` (region) | `[root.json, und-MK.json]` |
+| `"MK"` (region-only) | `[root.json, und-MK.json]` |
 | `"zh-Hans-CN"` | `[root.json, zh.json, und-Hans.json, zh-Hans.json, und-CN.json, zh-CN.json, zh-Hans-CN.json]` |
 
 ### Deep Merge Strategy
@@ -111,136 +117,6 @@ More specific locales override less specific ones.
 
 ---
 
-## Core Components
-
-### 1. ILibLocale Module (`lib/ilib_locale.dart`)
-
-**Responsibility**: Parse, validate, and normalize locale strings per BCP-47 standard
-
-**Key Methods**:
-```dart
-// Parsing
-ILibLocale(string)          // Parse from string
-ILibLocale(lang, region)    // Construct from parts
-
-// Getters
-getLanguage() → String?     // ISO 639 code
-getRegion() → String?       // ISO 3166 code
-getScript() → String?       // ISO 15924 code
-getVariant() → String?      // Variant identifier
-getSpec() → String          // Full normalized spec
-```
-
-**Validation Rules**:
-- Language: `[a-z]{2,3}` (2-3 lowercase letters)
-- Script: `[A-Z][a-z]{3}` (1 uppercase + 3 lowercase)
-- Region: `[A-Z]{2}` or `[0-9]{3}` (2 uppercase or 3 digits)
-
-### 2. ILibLocaleInfo Module (`lib/ilib_localeinfo.dart`)
-
-**Responsibility**: Retrieve and serve localization data by locale
-
-**Key Methods**:
-```dart
-ILibLocaleInfo(locale)          // Create with locale
-getRegionName() → String?       // e.g., "South Korea"
-getLanguageName() → String      // e.g., "Korean"
-getClock() → String             // "12" or "24"
-getTimeZone() → String          // e.g., "Asia/Seoul"
-getDecimalSeparator() → String  // e.g., "."
-getGroupingSeparator() → String // e.g., ","
-getFirstDayOfWeek() → int       // 0 (Sunday) to 6 (Saturday)
-getWeekEndStart() → int
-getWeekEndEnd() → int
-```
-
-**Data Source**: Downloaded locale JSON files in `assets/locale/`
-
-### 3. ILibDate / ILibDateFmt Modules (`lib/ilib_date.dart`, `lib/ilib_datefmt.dart`)
-
-**Responsibility**: Represent a date (`ILibDate` interface; `ILibDateOptions` implementation) and
-format it per locale (`ILibDateFmt`). `ILibDate` is an interface — build a date with
-`ILibDateOptions(...)`, then format with `ILibDateFmt(...).format(date)`.
-
-**Key Methods**:
-```dart
-final date = ILibDateOptions(year: 2011, month: 9, day: 29);
-final fmt = ILibDateFmt(ILibDateFmtOptions(
-  locale: 'ko-KR',
-  length: 'short'|'medium'|'long'|'full',
-  type: 'date'|'time'|'datetime',
-));
-fmt.format(date) → String
-```
-
-### 4. ILibCalendar Module (`lib/ilib_calendar.dart` + `lib/calendar/`)
-
-**Responsibility**: Calendar rules and the calendar factory; per-calendar date/Rata-Die classes.
-
-**Key Methods**:
-```dart
-ILibCalendar([type])            // factory; default gregorian
-ILibCalendar.fromLocale(locale)
-getType() → String
-getNumMonths(int year) → int
-getMonLength(int month, int year) → int
-isLeapYear(int year) → bool
-```
-9 calendars: gregorian, thaisolar, julian, islamic, hebrew, ethiopic, coptic, persian
-(astronomical), persian-algo (algorithmic). See `docs/date-calendar-architecture.md`.
-
-### 5. ILibTimeZone Module (`lib/ilib_timezone.dart`)
-
-**Responsibility**: Timezone offset and DST calculation from bundled `zoneinfo`; `'local'` =
-DST-aware system timezone.
-
-**Key Methods**:
-```dart
-ILibTimeZone(id) / .fromOffset(min) / .fromLocale(locale) / .defaultZone()
-getId() → String
-getOffsetMinutes(ILibDate date, {wallTime}) → double
-inDaylightTime(ILibDate date) → bool
-getDisplayName(ILibDate date, [style]) → String   // 'PST'/'PDT', 'rfc822', 'long'
-```
-
-### 6. ILibCaseMapper Module (`lib/ilib_casemapper.dart`)
-
-**Responsibility**: Perform locale-aware case conversion
-
-**Key Methods**:
-```dart
-final mapper = ILibCaseMapper(locale);
-mapper.toLowerCase(String) → String
-mapper.toUpperCase(String) → String
-mapper.toLocaleString(String) → String
-```
-
-**Example**: Turkish `İ` (capital dotted I) → `i̇` (lowercase dotted i)
-
-### 7. ILibLoader Module (`lib/ilib_init.dart`)
-
-**Responsibility**: Manage locale data loading and caching
-
-**Pattern**: Singleton
-
-**Key Methods**:
-```dart
-ILibLoader.instance                  // Global access
-getLocaleData(locale) → Map?         // Cached data
-_mergeFromCache(locale)              // Build from file cache
-_deepMerge(base, override) → Map    // Merge strategy
-loadJSON()                           // Initialize with current locale
-initILib()                           // Mark ready (validates data loaded)
-loadILibLocaleData(locale)           // Load additional locale
-loadILibLocaleDataAll()              // Load all supported locales
-```
-
-**Caching Strategy**:
-- `_localeDataMap`: Merged data by locale (fast lookup)
-- `_fileDataCache`: Individual JSON files (reusable)
-
----
-
 ## Directory Structure
 
 ```
@@ -252,15 +128,19 @@ flutter_ilib/
 │   ├── ilib_date.dart           (ILibDateOptions: date options/calculation)
 │   ├── ilib_date_accessor.dart  (ILibDate interface)
 │   ├── ilib_datefmt.dart        (date/time formatting engine)
+│   ├── ilib_durationfmt.dart    (duration formatting)
+│   ├── ilib_numfmt.dart         (number & currency formatting)
 │   ├── ilib_timezone.dart       (timezone / DST)
 │   ├── ilib_calendar.dart       (calendar factory + abstract base)
-│   ├── ilib_casemapper.dart     (case conversion)
+│   ├── ilib_casemapper.dart     (locale-aware case conversion)
+│   ├── ilib_scriptinfo.dart     (script metadata)
+│   ├── ilib_country.dart        (country code ↔ name lookup)
+│   ├── ilib_currency.dart       (currency metadata)
 │   ├── ilib_init.dart           (ILibLoader: data load/merge/cache)
 │   ├── calendar/                (9 calendars: {name}_cal/_date/_rata_die.dart,
 │   │                             rata_die.dart, ilib_astro.dart, julian_day.dart)
 │   └── internal/
-│       ├── ilib_utils.dart      (getJSONDataPaths, getJSONDataPath,
-│       │                         isValidLocale, getSupportedLocales)
+│       ├── ilib_utils.dart      (getJSONDataPaths, isValidLocale, getSupportedLocales)
 │       └── logger/              (logging)
 │
 ├── assets/
@@ -295,10 +175,8 @@ Each JSON file contains:
     "timezone": "Asia/Seoul",
     "numfmt": {
       "decimalChar": ".",
-      "groupChar": ",",
-      ...
-    },
-    ...
+      "groupChar": ","
+    }
   }
 }
 ```
@@ -306,118 +184,55 @@ Each JSON file contains:
 ### Merging Example
 
 For locale `"ko-KR"`, load order:
-1. `root.json` - Base defaults
-2. `ko.json` - Korean language specifics
-3. `und-KR.json` - South Korea region specifics
-4. `ko-KR.json` - Full ko-KR locale specifics
+1. `root.json` — base defaults
+2. `ko.json` — Korean language specifics
+3. `und-KR.json` — South Korea region specifics
+4. `ko-KR.json` — full ko-KR locale specifics
 
-Each level **overrides** previous levels.
-
----
-
-## Validation Logic
-
-### isValidLocale() Function
-
-```dart
-bool isValidLocale(String lo) {
-  const String bcp47Pattern =
-      r'(^|[^a-z])([a-z][a-z][a-z]?)(-([A-Z][a-z][a-z][a-z]))?(-([A-Z][A-Z]))?$';
-  const String regionOnlyPattern = r'^[A-Z][A-Z]$';
-
-  if (RegExp(bcp47Pattern).hasMatch(lo)) {
-    return true;  // Standard BCP-47: en, en-US, zh-Hans-CN
-  }
-
-  return RegExp(regionOnlyPattern).hasMatch(lo);  // Region-only: MK, TR
-}
-```
-
-**Regex Breakdown (BCP-47)**:
-- `(^|[^a-z])` - Start or non-lowercase char
-- `([a-z][a-z][a-z]?)` - Language: 2-3 lowercase letters
-- `(-([A-Z][a-z][a-z][a-z]))?` - Optional script: hyphen + titlecase 4 chars
-- `(-([A-Z][A-Z]))?` - Optional region: hyphen + 2 uppercase letters
-- `$` - End of string
-
----
-
-## Recent Improvements (v2.0.0)
-
-### 1. Region-Only Locale Support
-
-**Before**: `'MK'` → Invalid, no data loaded  
-**After**: `'MK'` → Valid, loads `und-MK.json`
-
-**Implementation**:
-- Added `regionOnlyPattern` regex to `isValidLocale()`
-- Updated `getJSONDataPaths()` to handle `language == null && region != null`
-
-### 2. Path Normalization
-
-Both region and script `und-*` fallbacks use a **hyphen**: `und-{REGION}.json`, `und-{SCRIPT}.json`.
-
-**Rationale**: Consistency with the bundled file naming (all `und-*` files use a hyphen).
-
-### 3. Test Coverage Updates
-
-Updated 5 tests to match implementation:
-- `language-region (ko-KR)`: Now expects `und-KR.json` (hyphen)
-- `language-region (en-US)`: Now expects `und-US.json` (hyphen)
-- `language-script-region (zh-Hans-CN)`: Added intermediate `zh-CN.json`
-- `language-script-region (ku-Arab-IQ)`: Added intermediate `ku-IQ.json`
-- `path order` test: Updated expected path count from 6 to 7
+Each level overrides previous levels.
 
 ---
 
 ## Design Patterns
 
-### Singleton Pattern
-`ILibLoader` is a singleton for global locale data loading/caching.
+### Singleton
+`ILibLoader` is a singleton for global locale data loading and caching.
 
-### Factory Pattern
+### Factory
 `ILibLocale` and `ILibCalendar` use factory constructors for flexible construction.
 
-### Strategy Pattern
-`getJSONDataPaths()` implements the merge strategy for locale data.
-
-### Caching Pattern
-Two-level cache in `ILibLoader`:
-- File cache: Raw JSON from disk
-- Locale cache: Merged data ready for use
+### Two-Level Cache (`ILibLoader`)
+- **File cache** (`_fileDataCache`): raw JSON from disk — avoids redundant I/O
+- **Locale cache** (`_localeDataMap`): merged data by locale — avoids re-merging on repeated access
 
 ---
 
 ## Performance Considerations
 
-### Loading Time
-- Lazy loading: Load only the current locale + fallbacks
-- File caching prevents redundant I/O
-
-### Memory Usage
-- Merged data cached in memory per locale
-- Avoids re-merging on repeated access
+### Loading
+- Lazy loading: only the current locale + its fallback chain are loaded at startup
+- File cache prevents redundant disk reads when multiple locales share the same fallback files
 
 ### Optimization Tips
-- Load locale data early in app startup
-- Cache locale-specific objects (`ILibLocaleInfo`)
-- Reuse `ILibLocale` instances when possible
+- Load locale data early in app startup (`ILibLoader.instance.loadJSON()`)
+- Load additional locales ahead of time with `loadILibLocaleData(locale)`
+- Reuse `ILibDateFmt` / `ILibNumFmt` instances across multiple format calls
 
 ---
 
 ## Dependencies & Integration
 
 ### Internal Dependencies
-- `lib/ilib_locale.dart` ← used by `ilib_utils.dart`, all other modules
+- `lib/ilib_locale.dart` ← used by `ilib_utils.dart` and all other modules
 - `lib/ilib_init.dart` ← used by all modules for data loading
 
 ### External Dependencies
-- `flutter: sdk` - Flutter framework
-- `logging: ^1.2.0` - Logging utilities
-- `plugin_platform_interface: ^2.0.2` - Multi-platform support
+- `flutter: sdk` — Flutter framework
+- `logging: ^1.2.0` — logging utilities
+- `plugin_platform_interface: ^2.0.2` — multi-platform support
 
 ### Asset Dependencies
-- `assets/locale/*.json` - iLib locale data files (~251 files)
+- `assets/locale/*.json` — iLib locale data files (~251 files)
 
 ---
 

--- a/docs/conversion-guide.md
+++ b/docs/conversion-guide.md
@@ -2,11 +2,6 @@
 
 Guide for converting flutter_ilib's JavaScript interop dependencies to pure Dart.
 
-## Background
-
-- **develop branch**: Uses `flutter_js` package's `JavascriptRuntime` to evaluate iLib JS library at runtime
-- **convertToDart branch**: Removes JS runtime → loads JSON locale data directly and processes in pure Dart
-
 ## Conversion Status
 
 ### Completed
@@ -19,6 +14,7 @@ Guide for converting flutter_ilib's JavaScript interop dependencies to pure Dart
 | `ILibLoader` | `lib/ilib_init.dart` | JSON load via `rootBundle` (replaces `ILibJS`) |
 | `ILibDate` | `lib/ilib_date.dart` | No JS dependency |
 | `ILibDateFmt` | `lib/ilib_datefmt.dart` | Pure Dart formatting engine |
+| `ILibDurationFmt` | `lib/ilib_durationfmt.dart` | Pure Dart duration formatting |
 | `ILibTimeZone` | `lib/ilib_timezone.dart` | DST calculation from zoneinfo JSON |
 | `ILibCalendar` | `lib/ilib_calendar.dart` + `lib/calendar/` | Calendar factory + all calendar types |
 | `ILibCurrency` | `lib/ilib_currency.dart` | Currency metadata lookup and resolution |
@@ -42,7 +38,7 @@ String getClock() {
 ### After (Pure Dart)
 
 ```dart
-// convertToDart branch — direct lookup from JSON data
+// pure Dart — direct lookup from JSON data
 String getClock() {
   return (_info['clock'] as String?) ?? (_defaultInfo['clock'] as String);
 }
@@ -52,7 +48,7 @@ String getClock() {
 
 ### 1. Data Analysis
 
-- [ ] Identify data keys used by the class from `ilib_js/{ClassName}.js`
+- [ ] Identify data keys used by the class from the JS source (`js/lib/` at the pinned iLib tag — see CLAUDE.md › Source Versions)
 - [ ] Verify JSON key in `assets/locale/root.json` (e.g., `ilib.data.localeinfo`)
 - [ ] Confirm required data already exists in JSON files
 
@@ -72,14 +68,14 @@ String getClock() {
 
 ### 4. Test Conversion
 
-- [ ] Convert tests from `js/test/calendar/test{class}.js` to Dart
+- [ ] Convert tests from `js/test/` at the pinned iLib tag to Dart
 - [ ] **NEVER modify test expected values** — if a test fails, the Dart implementation has a bug, not the test data
 - [ ] Test data (e.g., `testDatesCoptic` reference arrays) must match JS source exactly
 - [ ] If a JS test cannot be converted due to missing Dart features (setters, timezone offset), document it in `docs/test-mapping.md` under "Not Converted" with the reason
 - [ ] **Do NOT convert JS tests for a locale that flutter_ilib does not support.** The authoritative list of supported locales is `scripts/assemble_ilib/locales.json` (the seed used to generate `assets/locale/`) — a per-locale test is in scope only if its locale is in that list.
-  - When the data is fully absent, `ILibLocaleInfo`/`ILibTimeZone.fromLocale` fall back to defaults (e.g. `Etc/UTC`) and the JS expected value (e.g. `Asia/Ashgabat`) cannot be reproduced — N/A (e.g. `testTZGetDefaultFor_tk_TM`/`_tg_TJ`/`_wo_SN`/`_zu_ZA`/`_mt_MT`).
-  - **Do not rely on "the value happens to reproduce" to decide.** An unsupported locale can still produce the JS value by language fallback (e.g. `ku-IQ` resolves via `ku` + `und-IQ`), yet it is out of scope because it is not in `locales.json`. Conversely, only convert the supported variant (e.g. `ku-Arab-IQ` **is** in the list; `ku-IQ`/`ku-TR` are not). Membership in `locales.json` — not data presence or accidental fallback — is the test.
-  - **Script-explicit 3-part locales** (e.g. `pa-Guru-IN`) whose 2-part form (`pa-IN`) is in `locales.json` are also in scope — port the JS test as-is. `pa-Guru-IN` is the BCP-47 form with an explicit script tag; it loads the same asset files as `pa-IN` and produces identical data. If neither 3-part nor 2-part is in `locales.json`, the test is N/A.
+  - When the data is fully absent, `ILibLocaleInfo`/`ILibTimeZone.fromLocale` fall back to defaults (e.g. `Etc/UTC`) and the JS expected value cannot be reproduced — N/A.
+  - **Do not rely on "the value happens to reproduce" to decide.** An unsupported locale can still produce the JS value by language fallback, yet it is out of scope because it is not in `locales.json`. Membership in `locales.json` — not data presence or accidental fallback — is the test.
+  - **Script-explicit 3-part locales** (e.g. `pa-Guru-IN`) whose 2-part form (`pa-IN`) is in `locales.json` are also in scope — port the JS test as-is. If neither 3-part nor 2-part is in `locales.json`, the test is N/A.
   - **Language-only locales** (e.g. `az`, `pa`) are in scope when at least one `{lang}-*` locale is in `locales.json` (meaning `{lang}.json` exists). If no `{lang}-*` locale is bundled, the language-only test is N/A (e.g. `ig`, `lb`).
 - [ ] Dart-specific additional tests (getDayOfYear, getEra, etc.) go in a separate `*_extra_test.dart` file
 
@@ -100,53 +96,12 @@ Dart API clearer without changing observable behaviour.
 | `ILibScriptInfo` | `new ScriptInfo()` — `script` is optional; omitting it yields an instance where all getters return defaults | `ILibScriptInfo(String script)` — `script` is required; pass `''` to replicate the JS no-arg behaviour | Dart requires explicit types; a no-arg constructor with no useful state is misleading |
 | `ILibNumFmt` | `constrain(number)` — accepts any JS number, returns `number` | `double constrain(num number)` — `num` accepts both `int` and `double`, returns `double` | JS has a single `number` type; Dart distinguishes `int`/`double` — `num` is the correct abstract supertype |
 
-## Core Infrastructure
-
-### ILibLoader (lib/ilib_init.dart)
-
-The core component of the conversion. Replaces `ILibJS` from the develop branch.
-
-```dart
-// Singleton access
-ILibLoader.instance
-
-// Locale data lookup (returns already-merged Map)
-Map<String, dynamic>? data = ILibLoader.instance.getLocaleData('ko-KR');
-
-// Access class-specific data
-Map<String, dynamic>? localeInfo = data?['ilib.data.localeinfo'];
-```
-
-### Data Load Flow
-
-```
-App start → ILibLoader.loadJSON()
-         → getJSONDataPaths(locale) generates file list to load
-         → Load in order: root.json → {lang}.json → und-{region}.json → {lang}-{region}.json
-         → Hierarchical merge via deepMerge
-         → Cache in _localeDataMap
-```
-
-### JSON Data Structure
-
-```json
-{
-  "ilib.data.currency": { ... },
-  "ilib.data.dateformats": { ... },
-  "ilib.data.localeinfo": { "clock": "24", "timezone": "Asia/Seoul", "numfmt": { ... }, ... },
-  "ilib.data.scripts": { ... },
-  "ilib.data.sysres":   { ... }
-}
-```
-
-Each JSON file may contain multiple `ilib.data.*` keys. After loading, they are deep-merged to compose the final data.
-
 ## Reference
 
 - Original JS source: https://github.com/iLib-js/iLib at the pinned tag → `js/lib/`
   (`git checkout <tag>`; tag = CLAUDE.md › Source Versions)
 - Original JS tests: https://github.com/iLib-js/iLib at the same tag → `js/test/`
-- Local `ilib_js/` — JS source copy (for quick reference only)
-- `assets/locale/` — hierarchical JSON locale data covering the supported locales (root → lang → und-script → lang-script → und-region → lang-region → lang-script-region; ~251 files), generated from the pinned iLib version (see CLAUDE.md › Source Versions)
-- `docs/architecture.md` — full architecture documentation
+- `assets/locale/` — hierarchical JSON locale data (~251 files), generated from the pinned iLib version (see CLAUDE.md › Source Versions)
+- `docs/architecture.md` — data loading and locale path generation
+- `docs/test-mapping.md` — JS↔Dart test file mapping and not-converted cases
 - `test/` — existing tests (for post-conversion verification)

--- a/docs/date-calendar-architecture.md
+++ b/docs/date-calendar-architecture.md
@@ -191,6 +191,7 @@ Matches JS `_init()` / `_init2()` / `_calcDateComponents()` pattern.
 ```
 lib/
 +-- ilib_date.dart              # ILibDateOptions (user API)
++-- ilib_date_accessor.dart     # ILibDate interface (year/month/day accessors)
 +-- ilib_datefmt.dart           # ILibDateFmt (formatting engine)
 +-- ilib_timezone.dart          # ILibTimeZone (DST calculation)
 +-- ilib_calendar.dart          # ILibCalendar (factory + abstract)
@@ -198,7 +199,7 @@ lib/
     +-- ilib_date.dart          # ILibCalendarDate (abstract base)
     +-- rata_die.dart           # ILibRataDie (abstract base)
     +-- julian_day.dart         # JulianDay helper
-    +-- calendar_utils.dart     # mod() helper
+    +-- calendar_utils.dart     # mod(), floorDiv() helpers
     +-- ilib_astro.dart         # Astronomical calculations
     +-- gregorian_cal.dart      # Calendar rules
     +-- gregorian_date.dart     # Date implementation

--- a/docs/datefmt-conversion-plan.md
+++ b/docs/datefmt-conversion-plan.md
@@ -260,8 +260,7 @@ ILibJS.instance.initILib();
 await ILibJS.instance.loadILibLocaleData('en-US');
 
 // After (Pure Dart)
-await ILibLoader.instance.loadJSON();
-ILibLoader.instance.initILib();
+await ILibLoader.instance.loadJSON();  // initILib() called internally
 await ILibLoader.instance.loadILibLocaleData('en-US');
 ```
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -105,16 +105,6 @@ flutter analyze lib/ilib_locale.dart
 flutter analyze --verbose
 ```
 
-### Linting
-
-```bash
-# Run custom linter rules
-flutter pub run custom_lint
-
-# Update linter configuration
-# Edit: analysis_options.yaml
-```
-
 ---
 
 ## Testing
@@ -239,32 +229,6 @@ const String apiVersion = '2.0.0';
 // Private members: prefix with underscore
 String _privateField;
 void _privateMethod() { }
-```
-
-### File Organization
-
-Each Dart file should follow:
-```dart
-// 1. Imports
-import 'dart:ui';
-import 'package:flutter/foundation.dart';
-import 'relative/path.dart';
-
-// 2. Part declarations (if used)
-part 'subfile.dart';
-
-// 3. Constants
-const String defaultLocale = 'en-US';
-
-// 4. Types/Typedefs
-typedef LocaleCallback = void Function(String);
-enum DateLength { short, medium, long, full }
-
-// 5. Main class
-class MyClass { }
-
-// 6. Standalone functions (if any)
-void helperFunction() { }
 ```
 
 ### Documentation
@@ -611,7 +575,7 @@ Before releasing version X.Y.Z:
 - [ ] Code formatted (`dart format .`)
 - [ ] CHANGELOG.md updated
 - [ ] Version bumped in `pubspec.yaml`
-- [ ] Notable features documented in `Docs.md`
+- [ ] Notable features documented in `docs/`
 - [ ] README examples work
 - [ ] No breaking changes (or clearly documented)
 - [ ] Git tag created: `vX.Y.Z`
@@ -632,7 +596,7 @@ Before releasing version X.Y.Z:
 ## Getting Help
 
 ### Questions?
-- Check `README.md` and `Docs.md`
+- Check `README.md` and `docs/`
 - Review existing issues: GitHub Issues
 - Review test examples in `test/`
 

--- a/docs/durationfmt-conversion-plan.md
+++ b/docs/durationfmt-conversion-plan.md
@@ -26,7 +26,7 @@ developer reference for maintenance and future conversions.
 
 > History: This replaced the JS interop calls in `lib/ilib_durationfmt.dart`
 > (`ILibJS.instance.evaluate('new DurationFmt(...).format(...)')`) with a pure-Dart
-> implementation. The unported `ILibCountry` remains the only class still on JS interop.
+> implementation. All classes are now pure Dart.
 
 ---
 
@@ -60,7 +60,7 @@ format(components)   // components is an ILibDateOptions
 ```
 lib/
 ├── ilib_durationfmt.dart      ← formatter + options
-├── internal/ilib_plural.dart  ← CLDR plural-rule evaluation (getPluralCategory)
+├── internal/plural_utils.dart  ← CLDR plural-rule evaluation (getPluralCategory)
 ├── ilib_datefmt.dart          ← reused for clock-style time rendering
 ├── ilib_scriptinfo.dart       ← script direction lookup
 ├── ilib_localeinfo.dart       ← script/clock/digits defaults
@@ -89,9 +89,9 @@ are copied verbatim from `DurationFmt.js`. `finalSeparator` is only non-empty at
 **medium downgrade**: JS forces `medium → short` when the locale script is not
 Latin, Greek, or Cyrillic. Same check applied in the constructor.
 
-### Step 2: Plural-choice engine (`_formatChoice` + `internal/ilib_plural.dart`)
+### Step 2: Plural-choice engine (`_formatChoice` + `internal/plural_utils.dart`)
 
-Plural-rule evaluation lives in `lib/internal/ilib_plural.dart` as stateless
+Plural-rule evaluation lives in `lib/internal/plural_utils.dart` as stateless
 top-level functions (no class — the only input is the rule map). The formatter
 calls `getPluralCategory(rules, n)`; the template-choice logic (`_formatChoice`)
 stays in `ilib_durationfmt.dart`.
@@ -203,7 +203,7 @@ flutter test test/durfmt/durfmt_or_IN_test.dart
 flutter test test/durfmt/durfmt_si_LK_test.dart
 flutter test test/durfmt/durfmt_sw_KE_test.dart
 
-# Full project regression (durfmt now included; only country is pruned)
+# Full project regression
 ./execute_unit_test.sh
 ```
 

--- a/docs/quick_reference.md
+++ b/docs/quick_reference.md
@@ -63,7 +63,7 @@ print(locale.region);    // 'US'
 
 ### Case Conversion
 ```dart
-final mapper = ILibCaseMapper('tr-TR');  // Turkish
+final mapper = ILibCaseMapper(locale: 'tr-TR');  // Turkish
 print(mapper.toLowerCase('İ'));  // 'i̇'
 ```
 
@@ -142,7 +142,7 @@ ILibDateFmt(ILibDateFmtOptions(...)).format(date)
 
 ### ILibCaseMapper
 ```dart
-ILibCaseMapper('en-US')
+ILibCaseMapper(locale: 'en-US')
 mapper.toLowerCase(str)
 mapper.toUpperCase(str)
 ```

--- a/docs/test-mapping.md
+++ b/docs/test-mapping.md
@@ -15,7 +15,7 @@ JS source path base: `js/test/`
 | `test/calendar/testthaisolardate_test.dart` | `js/test/testthaisolardate.js` | ThaiSolarDate |
 | `test/calendar/testjulian_test.dart` | `js/test/testcal_julian.js` | JulianCal |
 | `test/calendar/testjuliandate_test.dart` | `js/test/testjuliandate.js` | JulianDate |
-| `test/calendar/testjulianday_test.dart` | `js/test/testjulianday.js` | JulianDay helper (getDate/getDays/getDayFraction/setDate/setDays/setDayFraction/addDate). `addDate` returns a new instance in Dart (JS mutates in place); see Not Converted for the one untranslatable case |
+| `test/calendar/testjulianday_test.dart` | `js/test/testjulianday.js` | JulianDay helper (getDate/days/getDayFraction/setDate/setDayFraction/addDate). `addDate` returns a new instance in Dart (JS mutates in place); see Not Converted for the one untranslatable case |
 | `test/calendar/testislamic_test.dart` | `js/test/testcal_islamic.js` | IslamicCal |
 | `test/calendar/testislamicdate_test.dart` | `js/test/testislamicdate.js` | IslamicDate |
 | `test/calendar/testhebrew_test.dart` | `js/test/testcal_hebrew.js` | HebrewCal |
@@ -271,7 +271,7 @@ Total: ~15 tests per calendar, ~135 tests across all 9 calendars.
 | Test | File | Count | Reason |
 |---|---|---|---|
 | `testEthiopicGetMonLength14/15/16`, `testEthiopicIsLeapYear5/6` | `testethiopic.js` | 5 | JS passes `String`/`undefined` args (`getMonLength("15")`, `getMonLength(undefined)`, `isLeapYear("2009")`, `isLeapYear(undefined)`) to exercise dynamic-type coercion. Dart `getMonLength(int, int)` / `isLeapYear(int)` take non-nullable `int`, so `String`/`undefined` are not expressible (same reason as `*DateConstructorFullWithStrings`). The meaningful integer behavior is already covered — e.g. `getMonLength("13","2007") → 6` equals the Dart `GetMonLength 13 LeapYear` test (`getMonLength(13, 2007) → 6`). Only `testethiopic.js` has these edge tests; the other 8 cal test files do not. |
-| `testJulianDaySetDaysIgnoreFraction` | `testjulianday.js` | 1 | JS calls `setDays(2.9)` with a float to verify the fractional part is dropped. Dart `setDays(int)` takes a non-nullable `int`, so a float cannot be passed (same reason as `*DateConstructorFullWithStrings`). The other 9 JulianDay tests are converted. |
+| `testJulianDaySetDaysIgnoreFraction` | `testjulianday.js` | 1 | JS calls `setDays(2.9)` with a float to verify the fractional part is dropped. Dart `days` is a non-nullable `int` field, so a float cannot be assigned (same reason as `*DateConstructorFullWithStrings`). The other 9 JulianDay tests are converted. |
 
 ## Commented-out / disabled in the JS source (not real tests)
 

--- a/docs/test-mapping.md
+++ b/docs/test-mapping.md
@@ -295,7 +295,7 @@ dynamic-typing features that don't exist in the Dart port:
 | `*NonIDate` | 22 | `testTZGetOffsetDSTNonIDate`, `testTZDisplayName*NonIDate`, `testTZInDaylightTime*NonIDate` | JS passes a native `Date` (or plain object) instead of an iLib `IDate`, e.g. `tz.getOffset(new Date(2011, 7, 1))`. Dart's `getOffset`/`inDaylightTime`/`getDisplayName` take a typed `ILibDate`, so a native date can't be passed. The `IDate` variant of each IS converted; the Dart-idiomatic "non-iLib date input" is provided separately via `DateTime` and tested in `timezone_extra_test.dart` (`testTZGetOffsetDateTime*`, `testTZInDaylightTimeDateTime*`, `testTZDisplayNameDateTime*`). |
 | `*WithLoader` / `*Asynch` | 10 | `testTZGetTimeZoneWithLoaderAsynch`, `testGetAvailableTimeZonesWithLoader`, `testTZGetTimeZoneForLocaleWithLoaderNoData` | Exercise the JS async loader callback (`ilib.setLoaderCallback(...)`, `sync: false`). Dart uses the synchronous asset-based `ILibLoader`; there is no async-callback loader to test. |
 | `*WithIlibString` | 3 | `testTZConstructorWithIlibString`, `testTZConstructorLocalWithIlibString`, `testTZGetWithIlibString` | Construct with an iLib `IString` wrapper (`new TimeZone({id: new IString("America/Los_Angeles")})`). Dart uses a plain `String`; there is no `IString` type. The `String` constructor IS covered. |
-| `testTZGetDefaultFor_{tg_TJ,tk_TM,wo_SN,zu_ZA}`, `testTZGetDefaultLocale_mt_MT` | 5 | — | Unsupported locales (tg/tk/wo/zu/mt not in the bundled 218); see the unsupported-locale rule in CLAUDE.md. |
+| `testTZGetDefaultFor_{tg_TJ,tk_TM,wo_SN,zu_ZA}`, `testTZGetDefaultLocale_mt_MT` | 5 | — | Unsupported locales (tg/tk/wo/zu/mt not in the bundled 144); see the unsupported-locale rule in CLAUDE.md. |
 
 ## Assertion Conversion Patterns
 

--- a/lib/calendar/julian_day.dart
+++ b/lib/calendar/julian_day.dart
@@ -8,31 +8,24 @@ library;
 class JulianDay {
   /// Create a [JulianDay] from the Julian Day number [jd].
   JulianDay(double jd)
-      : _days = jd.floor(),
+      : days = jd.floor(),
         _fraction = jd - jd.floor();
 
-  int _days;
+  /// The integer (whole-day) part of the Julian Day number.
+  int days;
+
   double _fraction;
 
   /// The full Julian Day number (integer part + fractional part).
-  double getDate() => _days + _fraction;
-
-  /// The integer (whole-day) part of the Julian Day number.
-  int getDays() => _days;
+  double getDate() => days + _fraction;
 
   /// The fractional (sub-day) part of the Julian Day number (0.0–1.0).
   double getDayFraction() => _fraction;
 
   /// Replace this value with [jd].
   void setDate(double jd) {
-    _days = jd.floor();
+    days = jd.floor();
     _fraction = jd - jd.floor();
-  }
-
-  // ignore: use_setters_to_change_properties
-  /// Set the integer day part to [days].
-  void setDays(int days) {
-    _days = days;
   }
 
   /// Set the fractional day part to the fractional portion of [frac].

--- a/lib/ilib_locale.dart
+++ b/lib/ilib_locale.dart
@@ -1,6 +1,8 @@
 /// {@category API}
 library;
 
+import 'internal/ilib_utils.dart';
+
 /// A parsed BCP-47 locale identifier (language, script, region, variant).
 ///
 /// Accepts a BCP-47 string (e.g. `'zh-Hans-CN'`), an existing [ILibLocale]
@@ -971,9 +973,7 @@ class ILibLocale {
   }
 
   /// Return all available locale specifiers.
-  ///
-  /// Not yet implemented.
   static List<String> getAvailableLocales() {
-    throw UnimplementedError('getAvailableLocales is not implemented yet');
+    return getSupportedLocales();
   }
 }

--- a/test/calendar/testjulianday_test.dart
+++ b/test/calendar/testjulianday_test.dart
@@ -5,8 +5,8 @@ import 'package:flutter_test/flutter_test.dart';
 // JulianDay is a pure calculation class — no locale/asset loading needed.
 //
 // Not converted: testJulianDaySetDaysIgnoreFraction — JS calls setDays(2.9) with a
-// float to verify the fraction is dropped. Dart setDays(int) takes a non-nullable int,
-// so a float cannot be passed (same reason as *DateConstructorFullWithStrings).
+// float to verify the fraction is dropped. Dart `days` is a non-nullable int field,
+// so a float cannot be assigned (same reason as *DateConstructorFullWithStrings).
 void main() {
   group('JulianDay', () {
     test('testJulianDayConstructor', () {
@@ -19,7 +19,7 @@ void main() {
     });
     test('testJulianDayGetDays', () {
       final JulianDay jd = JulianDay(1721791.25);
-      expect(jd.getDays(), 1721791);
+      expect(jd.days, 1721791);
     });
     test('testJulianDayGetDayFraction', () {
       final JulianDay jd = JulianDay(1721791.25);
@@ -37,8 +37,8 @@ void main() {
     test('testJulianDaySetDays', () {
       final JulianDay jd = JulianDay(1721791.25);
       expect(jd.getDate(), 1721791.25);
-      jd.setDays(2);
-      expect(jd.getDays(), 2);
+      jd.days = 2;
+      expect(jd.days, 2);
       expect(jd.getDate(), 2.25);
     });
     test('testJulianDaySetDayFraction', () {

--- a/test/localeinfo/locale_extra_test.dart
+++ b/test/localeinfo/locale_extra_test.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_ilib/flutter_ilib.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ILibLocale.getAvailableLocales', () {
+    test('returns a non-empty list', () {
+      final List<String> locales = ILibLocale.getAvailableLocales();
+      expect(locales, isNotEmpty);
+    });
+    test('contains known supported locales', () {
+      final List<String> locales = ILibLocale.getAvailableLocales();
+      expect(locales, contains('en-US'));
+      expect(locales, contains('ko-KR'));
+      expect(locales, contains('zh-Hans-CN'));
+    });
+    test('returns 144 locales', () {
+      expect(ILibLocale.getAvailableLocales().length, 144);
+    });
+  });
+}


### PR DESCRIPTION
### Checklist

The following lists affects Pub Points on pub.dev when the package is published.
* [ ] Passed the all tests.
* [ ] Verified that the example app works.
* [ ] Executed the `dart format` command.
* [ ] Added the API description is added if necessary.

## Summary

- **`JulianDay` simplification**: replace `getDays()`/`setDays()` with a public `days` field — more idiomatic Dart; eliminates a `// ignore: use_setters_to_change_properties` suppression
- **`ILibLocale.getAvailableLocales()`**: implement the previously `UnimplementedError`-throwing method by delegating to `getSupportedLocales()`; add `test/localeinfo/locale_extra_test.dart`
- **Fix locale count**: 218 → 144 in `CLAUDE.md` and `docs/test-mapping.md` (144 = `locales.json` entries; 252 = asset files)
- **`docs/` revision**: remove content duplicated by dartdoc, fix inaccurate API/file references, and remove stale descriptions across 10 files:
  - `api.md`: rewritten as class-overview + usage-flow guide (method lists delegated to dartdoc)
  - `architecture.md`: remove Core Components method lists, Validation Logic, and Recent Improvements sections; add missing classes
  - `conversion-guide.md`: add `ILibDurationFmt` to completed table; remove `ilib_js/` reference and architecture.md-duplicated sections
  - `development.md`: remove non-existent `custom_lint` section and unused `part` directive example
  - `INDEX.md`: remove stale `Docs.md`/`Tips.md` references, Document Metadata, Knowledge Graph
  - `quick_reference.md`: fix `ILibCaseMapper` positional → named params (`locale:`)
  - `durationfmt-conversion-plan.md`: `ilib_plural.dart` → `plural_utils.dart` (3 occurrences); remove stale "ILibCountry on JS interop" note
  - `date-calendar-architecture.md`: add missing `ilib_date_accessor.dart`; add `floorDiv()` to `calendar_utils.dart` description
  - `datefmt-conversion-plan.md`: remove redundant `initILib()` call in migration example
  - `CLAUDE.md`: fix `plural_utils.dart` filename and `ilib.data.scripts` key
- **`README.md`**: add Calendar Date, Calendar Meta, and Calendar Formatting examples; remove stale `## CLASS` section (linked to non-existent `Docs.md`)

## Test plan

- [ ] `flutter test` — all tests pass
- [ ] `flutter analyze` — no issues
- [ ] `dart format --output=none --set-exit-if-changed .` — no formatting changes
- [ ] `ILibLocale.getAvailableLocales()` returns 144 locales (`locale_extra_test.dart`)
