### PR TITLE
[migration/ilib-js-to-dart] fix(timezone): correct DST boundary comparisons and add date_test.dart

### DIFF
--- a/docs/local-timezone-support.md
+++ b/docs/local-timezone-support.md
@@ -61,6 +61,13 @@ CLAUDE.md to keep that file lean):
   `true` (from-components, wall): `startRd += dstSavings/1440`. `calcTimezoneOffset()` passes
   `wallTime=false`; `adjustRdForTimezone()` passes `wallTime=true`. A date passed to
   `getOffset()`/`inDaylightTime()` must carry the timezone it should be interpreted in.
+- **JD round-trip precision:** `getJulianDay() - GregRataDie.epoch` introduces a sub-nanosecond
+  floating-point error (≈ ±2.3e-10 days, ≈ ±20 ns) because the epoch magnitude shifts the IEEE 754
+  ULP. JS avoids this by reading `date.rd.getRataDie()` directly; Dart compensates with a
+  `halfMs = 0.5/86400000` (≈ 5.8e-9 days, ≈ 500 ns) tolerance in the boundary comparisons:
+  `rdC = rd + halfMs; return rdC >= startRd && rdC < endRd`. Since `halfMs` is orders of magnitude
+  smaller than any 1 ms step (1.16e-5 days), all integer-millisecond timestamps produce the same
+  boolean result as JS.
 - DST-end overlap (`dst` flag): the same wall time occurs twice; `ILibDate` carries `bool? dst`
   threaded through every constructor and `_toCalendarDate()`. `inDaylightTime()` has the JS
   magic-overlap rule `if (dst != null && rd < endRd && endRd - rd <= dstSavings/1440) return dst;`
@@ -69,6 +76,11 @@ CLAUDE.md to keep that file lean):
 - `ILibRataDie.snapToMillis()` rounds an rd to millisecond resolution (mirrors iLib storing
   `halfup((jd - epoch) * 86400000) / 86400000`), applied in every `*RataDie` `julianDay`/`unixtime`
   branch so a `getTime()` round-trip lands on an exact instant (not `...999999999`).
+- **`_resolveDateOptions` UTC guard:** when `ILibDateFmt.format()` resolves a `unixtime`/`dateTime`
+  input to wall-clock components, it creates a temporary `ILibDateOptions(timezone: 'Etc/UTC')` to
+  probe the formatter's timezone offset. Without the explicit `'Etc/UTC'`, the temp date defaults to
+  `'local'`, causing `adjustRdForTimezone` to apply the system timezone twice and producing wrong DST
+  decisions (e.g. wrong AM/PM on DST boundaries in es-CL / America/Santiago).
 
 ## Optional future work — Strategy B (only for a real IANA `getId()`)
 

--- a/docs/test-mapping.md
+++ b/docs/test-mapping.md
@@ -41,6 +41,26 @@ JS source path base: `js/test/`
 | `test/calendar/testpersiandate_extra_test.dart` | — | flutter_ilib-specific (basic JD/date; getCalendar) |
 | `test/calendar/testthaisolardate_extra_test.dart` | — | flutter_ilib-specific (basic JD/date; getCalendar) |
 
+## Date / DateFactory Tests
+
+| Dart Test File | iLib JS Source File | Notes |
+|---|---|---|
+| `test/date/date_test.dart` | `js/test/date/testdate.js` | `ILibDateOptions` (DateFactory): constructor, mutable fields (set year/month/day/hour/minute/second/millisecond), factory type selection, DST boundary (Azores, Santiago). 18 of 32 active JS tests converted; see Not Converted below. |
+
+### Not Converted — Date/DateFactory Tests
+
+| JS Test | Reason |
+|---|---|
+| `testDateFactoryBogus` | JS returns `undefined` for an unknown `type`; Dart falls to the `default:` switch case and returns a `GregorianDate` — behavior differs |
+| `testDateToIlibUndefined`, `testDateToIlibNull`, `testDateToIlibDate*` (8), `testDateToIlib{Date,String,Integer,IlibDate}` | `DateFactory._dateToIlib()` is a JS-internal conversion utility (no Dart equivalent) |
+| `testDateGetJSDateBeyond32Bits` | `getJSDate()` returns a JS `Date` object — JS-specific, no Dart equivalent |
+| `testDstStartBoundary_Windhoek`, `testDstEndBoundary_Windhoek` | Commented out in the JS source |
+
+> **Note:** `testDateSet{Years,Months,Days,Hours,Minutes,Seconds,Milliseconds}` **are** converted for
+> `ILibDateOptions` (its fields are public and mutable: `gd.year = 123`). The same JS setter pattern
+> is N/A for `ILibCalendarDate` subclasses (immutable after construction) — see
+> [Common Not Converted Pattern](#common-not-converted-pattern-all-calendar-date-tests).
+
 ## DateFmt Locale Tests
 
 | Dart Test File | iLib JS Source File | Notes |

--- a/lib/ilib_datefmt.dart
+++ b/lib/ilib_datefmt.dart
@@ -238,6 +238,8 @@ class ILibDateFmt {
     if (dt != null) {
       if (dt.isUtc && _timezone != null && _timezone!.isNotEmpty) {
         final ILibTimeZone tz = ILibTimeZone(_timezone!, _zoneInfo);
+        // 'Etc/UTC' prevents adjustRdForTimezone from treating these UTC
+        // components as local time, which would corrupt DST decisions.
         final ILibDateOptions tempDate = ILibDateOptions(
           year: dt.year,
           month: dt.month,
@@ -245,6 +247,7 @@ class ILibDateFmt {
           hour: dt.hour,
           minute: dt.minute,
           second: dt.second,
+          timezone: 'Etc/UTC',
         );
         final double offsetMinutes = tz.getOffsetMinutes(tempDate);
         dt = dt.add(Duration(minutes: offsetMinutes.round()));

--- a/lib/ilib_timezone.dart
+++ b/lib/ilib_timezone.dart
@@ -322,10 +322,14 @@ class ILibTimeZone {
       return dst;
     }
 
+    // Half-ms tolerance absorbs the sub-nanosecond JD round-trip error
+    // (rd + epoch - epoch ≠ rd in IEEE 754) without affecting 1-ms boundaries.
+    const double halfMs = 0.5 / 86400000.0;
+    final double rdC = rd + halfMs;
     if (startRd < endRd) {
-      return rd >= startRd && rd < endRd;
+      return rdC >= startRd && rdC < endRd;
     }
-    return rd >= startRd || rd < endRd;
+    return rdC >= startRd || rdC < endRd;
   }
 
   bool _useDaylightTime() {

--- a/test/date/date_test.dart
+++ b/test/date/date_test.dart
@@ -1,0 +1,191 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_ilib/flutter_ilib.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  debugPrint('Testing [date_test.dart] file.');
+  setUpAll(() async {
+    await ILibLoader.instance.loadJSON();
+    await ILibLoader.instance.loadILibLocaleData('es-CL');
+  });
+
+  group('ILibDateOptions (DateFactory)', () {
+    test('testDateConstructor', () {
+      final ILibDateOptions gd = ILibDateOptions();
+      expect(gd, isNotNull);
+    });
+    test('testDateConstructorFull', () {
+      final ILibDateOptions gd = ILibDateOptions(
+        year: 2011,
+        month: 9,
+        day: 23,
+        hour: 16,
+        minute: 7,
+        second: 12,
+        millisecond: 123,
+      );
+      expect(gd, isNotNull);
+      expect(gd.year, 2011);
+      expect(gd.month, 9);
+      expect(gd.day, 23);
+      expect(gd.hour, 16);
+      expect(gd.minute, 7);
+      expect(gd.second, 12);
+      expect(gd.millisecond, 123);
+    });
+    test('testDateSetYears', () {
+      final ILibDateOptions gd = ILibDateOptions();
+      expect(gd, isNotNull);
+      gd.year = 123;
+      expect(gd.year, 123);
+    });
+    test('testDateSetMonths', () {
+      final ILibDateOptions gd = ILibDateOptions();
+      expect(gd, isNotNull);
+      gd.month = 7;
+      expect(gd.month, 7);
+    });
+    test('testDateSetDays', () {
+      final ILibDateOptions gd = ILibDateOptions();
+      expect(gd, isNotNull);
+      gd.day = 12;
+      expect(gd.day, 12);
+    });
+    test('testDateSetHours', () {
+      final ILibDateOptions gd = ILibDateOptions();
+      expect(gd, isNotNull);
+      gd.hour = 12;
+      expect(gd.hour, 12);
+    });
+    test('testDateSetMinutes', () {
+      final ILibDateOptions gd = ILibDateOptions();
+      expect(gd, isNotNull);
+      gd.minute = 13;
+      expect(gd.minute, 13);
+    });
+    test('testDateSetSeconds', () {
+      final ILibDateOptions gd = ILibDateOptions();
+      expect(gd, isNotNull);
+      gd.second = 23;
+      expect(gd.second, 23);
+    });
+    test('testDateSetMilliseconds', () {
+      final ILibDateOptions gd = ILibDateOptions();
+      expect(gd, isNotNull);
+      gd.millisecond = 123;
+      expect(gd.millisecond, 123);
+    });
+    test('testDateFactoryRightType', () {
+      final ILibDateOptions date = ILibDateOptions(type: 'gregorian');
+      expect(date, isNotNull);
+      expect(date.getCalendar(), 'gregorian');
+    });
+    test('testDateFactoryDefaultGregorian', () {
+      final ILibDateOptions date = ILibDateOptions();
+      expect(date, isNotNull);
+      expect(date.getCalendar(), 'gregorian');
+    });
+    test('testDateFactoryNonGregorian', () {
+      final ILibDateOptions date = ILibDateOptions(type: 'hebrew');
+      expect(date, isNotNull);
+      expect(date.getCalendar(), 'hebrew');
+    });
+    test('testDateFactoryNonGregorianWithCalendar', () {
+      final ILibDateOptions date = ILibDateOptions(calendar: 'hebrew');
+      expect(date, isNotNull);
+      expect(date.getCalendar(), 'hebrew');
+    });
+  });
+
+  group('DST boundary (getTimeExtended)', () {
+    test('testDstStartBoundary_Azores', () {
+      final ILibDateOptions boundaryiLib = ILibDateOptions(
+        year: 2019,
+        month: 3,
+        day: 31,
+        hour: 0,
+        minute: 0,
+        second: 0,
+        timezone: 'Atlantic/Azores',
+      );
+      expect(boundaryiLib.getTimeExtended(), 1553994000000);
+    });
+    test('testDstEndBoundary_Azores', () {
+      final ILibDateOptions boundaryiLib = ILibDateOptions(
+        year: 2019,
+        month: 10,
+        day: 27,
+        hour: 1,
+        minute: 0,
+        second: 0,
+        timezone: 'Atlantic/Azores',
+      );
+      expect(boundaryiLib.getTimeExtended(), 1572141600000);
+    });
+    test('testDstStartBoundary_Santiago', () {
+      final ILibDateOptions boundaryiLib = ILibDateOptions(
+        year: 2023,
+        month: 9,
+        day: 3,
+        hour: 0,
+        minute: 0,
+        second: 0,
+        timezone: 'America/Santiago',
+      );
+      expect(boundaryiLib.getTimeExtended(), 1693713600000);
+      final ILibDateOptions ildMyBday =
+          ILibDateOptions(unixtime: 1693713600000);
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+        length: 'short',
+        type: 'datetime',
+        locale: 'es-CL',
+        timezone: 'America/Santiago',
+      ));
+      expect(fmt.format(ildMyBday), '03-09-23, 1:00 a. m.');
+    });
+    test('testDstEndBoundary_Santiago', () {
+      final ILibDateOptions boundaryiLib = ILibDateOptions(
+        year: 2020,
+        month: 4,
+        day: 5,
+        hour: 0,
+        minute: 0,
+        second: 0,
+        timezone: 'America/Santiago',
+      );
+      expect(boundaryiLib.getTimeExtended(), 1586059200000);
+      final ILibDateOptions ildMyBday =
+          ILibDateOptions(unixtime: 1586059200000);
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+        length: 'short',
+        type: 'datetime',
+        locale: 'es-CL',
+        timezone: 'America/Santiago',
+      ));
+      expect(fmt.format(ildMyBday), '05-04-20, 12:00 a. m.');
+    });
+    test('testDstEndBoundary_Santiago2', () {
+      final ILibDateOptions boundaryiLib = ILibDateOptions(
+        year: 2020,
+        month: 4,
+        day: 4,
+        hour: 23,
+        minute: 0,
+        second: 0,
+        timezone: 'America/Santiago',
+      );
+      expect(1586059200000 - boundaryiLib.getTimeExtended(), 7200000);
+      expect(boundaryiLib.getTimeExtended(), 1586052000000);
+      final ILibDateOptions ildMyBday =
+          ILibDateOptions(unixtime: 1586052000000);
+      final ILibDateFmt fmt = ILibDateFmt(ILibDateFmtOptions(
+        length: 'short',
+        type: 'datetime',
+        locale: 'es-CL',
+        timezone: 'America/Santiago',
+      ));
+      expect(fmt.format(ildMyBday), '04-04-20, 11:00 p. m.');
+    });
+  });
+}


### PR DESCRIPTION
### Checklist

The following lists affects Pub Points on pub.dev when the package is published.
* [x] Passed the all tests.
* [x] Verified that the example app works.
* [x] Executed the `dart format` command.
* [x] Added the API description is added if necessary.

## Summary

- **fix(`inDaylightTime`)**: Add half-ms tolerance (`halfMs = 0.5/86400000`) to DST boundary
  comparisons. The `getJulianDay() - GregRataDie.epoch` round-trip introduces a sub-nanosecond
  IEEE 754 floating-point error (≈ ±20 ns) that was flipping boundary checks incorrectly,
  causing `testDstEndBoundary_Azores` and `testDstEndBoundary_Santiago*` to fail.
  `halfMs` is orders of magnitude smaller than any real 1-ms step, so all integer-millisecond
  timestamps produce identical boolean results to JS.

- **fix(`_resolveDateOptions`)**: Explicitly set `timezone: 'Etc/UTC'` on the temporary date
  created when resolving `unixtime`/`dateTime` inputs. Without it, a `null` timezone falls back
  to `'local'` (system TZ), causing `adjustRdForTimezone` to apply the system UTC offset twice
  to UTC components — producing wrong DST decisions and incorrect AM/PM output at DST boundaries
  (e.g. es-CL / America/Santiago).

- **test(`date_test.dart`)**: Convert `js/test/date/testdate.js` → `test/date/date_test.dart`.
  18 tests added: constructor, mutable field setters, factory type selection, and DST boundary
  cases (Azores, Santiago).

- **docs**: Document the `halfMs` precision fix and `_resolveDateOptions` UTC guard in
  `local-timezone-support.md`. Add a Date/DateFactory Tests section with N/A breakdown to
  `test-mapping.md`.

## Test plan

- [x] `flutter test test/date/date_test.dart` — all 18 tests pass
- [x] `flutter test test/calendar/timezone_test.dart` — no regression in existing 125 tests
- [x] `flutter test` — full suite passes
- [x] `flutter analyze` — no issues