### PR TITLE
[migration/ilib-js-to-dart] docs: bump iLib JS sync version reference to v15.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * Add system `'local'` timezone support (DST-aware, sampled from the OS). An omitted timezone now
   defaults to `'local'`, matching iLib JS; `'local'` and `'Etc/UTC'` therefore differ on a non-UTC
   host.
-* Based on iLib v14.22.0 / CLDR 48.2.
+* Based on iLib v15.0.0 / CLDR 48.2.
 * **Breaking**: `ILibCountry`, `ILibScriptInfo`, and `ILibDurationFmt` are not yet
   ported to pure Dart and are unavailable in this release; they are planned for a later 2.x.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,11 +9,11 @@ Reads JSON locale data directly and performs formatting/calculation in Dart.
 instead of repeating the numbers, so a version bump only changes the values here (plus the two
 point-in-time/public spots listed below).
 
-- **iLib JS source**: **v14.22.0** — all `lib/` Dart code and `test/` cases were converted
+- **iLib JS source**: **v15.0.0** — all `lib/` Dart code and `test/` cases were converted
   from the iLib JS at this tag (`js/lib/` and `js/test/` of github.com/iLib-js/iLib;
-  `git checkout v14.22.0`).
+  `git checkout v15.0.0`).
 - **CLDR data**: **48.2** — the bundled `assets/locale/` JSON (144 locales) was generated from
-  iLib v14.22.0, which incorporates CLDR 46.
+  iLib v15.0.0, which incorporates CLDR 46.
 - When updating to a newer iLib/CLDR: bump the JS source and the generated locale data
   **together** (a JS-only or data-only bump will diverge), then re-run the converted tests
   against the new JS expectations.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ locale information.
 > The change is internal only — the public API is the same across major versions, so your usage
 > code does not need to change when upgrading from v1.x to v2.0.
 
-The Dart implementation and the bundled locale data are based on **iLib v14.22.0** (which
+The Dart implementation and the bundled locale data are based on **iLib v15.0.0** (which
 incorporates **CLDR 48.2**).
 
 ## 📚 Documentation

--- a/example/integration_test/example_app_integration_test.dart
+++ b/example/integration_test/example_app_integration_test.dart
@@ -156,7 +156,7 @@ void main() {
             actual: _tryGetValueForLabel(tester, 'Country (KR)'),
             expected: expectedCountryValues[locale],
           );
-          
+
           _collectMismatch(
             failures: failures,
             locale: locale,

--- a/lib/flutter_ilib.dart
+++ b/lib/flutter_ilib.dart
@@ -41,7 +41,7 @@ class FlutterILib extends ChangeNotifier {
   String get getVersion => '2.0.0';
 
   /// Return the current version of iLib.
-  String get getILibVersion => '14.22.0';
+  String get getILibVersion => '15.0.0';
 
   /// Return the CLDR version currently adopted by iLib.
   String? get getCLDRVersion => '48.2';

--- a/test/basic/flutter_ilib_test.dart
+++ b/test/basic/flutter_ilib_test.dart
@@ -12,7 +12,7 @@ void main() {
   });
   group('Basic', () {
     test('getILibVersion',
-        () => expect(flutterIlibPlugin.getILibVersion, '14.22.0'));
+        () => expect(flutterIlibPlugin.getILibVersion, '15.0.0'));
     test('getCLDRVersion',
         () => expect(flutterIlibPlugin.getCLDRVersion, '48.2'));
     test('isILibReady', () => expect(flutterIlibPlugin.isILibReady, true));


### PR DESCRIPTION
### Checklist
The following lists affects Pub Points on pub.dev when the package is published.
* [ ] Passed the all tests.
* [ ] Verified that the example app works.
* [ ] Executed the `dart format` command.
* [ ] Added the API description is added if necessary.

### Description
No logic changes from v14.22.0; documentation references updated in CLAUDE.md, README.md, and CHANGELOG.md