### PR TITLE
[migration/ilib-js-to-dart] feat: add locale and cache management API to FlutterILib/ILibLoader

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ To load the updated locale data file when the locale changes, I suggest adding t
 
 ``` _flutterIlibPlugin.loadLocaleData(curLocale);```  
 
-> **Note:** `loadLocaleData` is what actually loads the data and notifies listeners. Setting the app-wide default `_flutterIlibPlugin.locale = '<locale>'` only changes the default used when no per-call `locale` is given — it does **not** load data. Whenever you switch to a locale whose data has not been loaded yet, you must call `loadLocaleData('<locale>')`; otherwise consumers fall back to default data.  
+> **Note:** `loadLocaleData('<locale>')` loads the data, notifies listeners, **and** updates the app-wide default locale — so a single call is all you need when switching locales. The setter `_flutterIlibPlugin.locale = '<locale>'` only changes the default string; it does **not** load data, so use it only to point the default at a locale that is already loaded. If you switch to a locale whose data is not loaded yet without calling `loadLocaleData`, consumers fall back to default data.  
 
 Here is an example of using the [localeResolutionCallback](https://api.flutter.dev/flutter/widgets/WidgetsApp/localeResolutionCallback.html)  property.  
 i.e:
@@ -73,7 +73,7 @@ Widget build(BuildContext context) {
 ```
 
 #### Reclaiming locale memory (optional)
-Loaded locale data is cached for reuse and normally does not need clearing. If you loaded many locales (e.g. via `loadILibLocaleDataAll`) and want to reclaim memory for ones you no longer use, call:
+Loaded locale data is cached for reuse and normally does not need clearing. If you have loaded many locales and want to reclaim memory for ones you no longer use, call:
 
 ```dart
 _flutterIlibPlugin.clearLocaleData('<locale>');

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ To load the updated locale data file when the locale changes, I suggest adding t
 
 ``` _flutterIlibPlugin.loadLocaleData(curLocale);```  
 
+> **Note:** `loadLocaleData` is what actually loads the data and notifies listeners. Setting the app-wide default `_flutterIlibPlugin.locale = '<locale>'` only changes the default used when no per-call `locale` is given — it does **not** load data. Whenever you switch to a locale whose data has not been loaded yet, you must call `loadLocaleData('<locale>')`; otherwise consumers fall back to default data.  
+
 Here is an example of using the [localeResolutionCallback](https://api.flutter.dev/flutter/widgets/WidgetsApp/localeResolutionCallback.html)  property.  
 i.e:
 ```dart
@@ -69,6 +71,15 @@ Widget build(BuildContext context) {
         localeResolutionCallback: appLocaleResolutionCallback,
     ....
 ```
+
+#### Reclaiming locale memory (optional)
+Loaded locale data is cached for reuse and normally does not need clearing. If you loaded many locales (e.g. via `loadILibLocaleDataAll`) and want to reclaim memory for ones you no longer use, call:
+
+```dart
+_flutterIlibPlugin.clearLocaleData('<locale>');
+```
+
+This drops only that locale's merged data; iLib stays ready, other locales are untouched, and the data is re-merged cheaply on next access.
 
 ### Examples
 Get the result of formatting by using the class provided by flutter_ilib.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -205,6 +205,22 @@ Each level overrides previous levels.
 - **File cache** (`_fileDataCache`): raw JSON from disk — avoids redundant I/O
 - **Locale cache** (`_localeDataMap`): merged data by locale — avoids re-merging on repeated access
 
+Both caches key locales by their **normalized** form (`ko_KR` → `ko-KR`), so
+`getLocaleData`, `loadILibLocaleData`, and `clearLocale` all resolve the same
+entry regardless of spelling.
+
+**Clearing:**
+- `clearLocale(locale)` (public, via `FlutterILib.clearLocaleData`) drops one
+  locale's merged entry to reclaim memory. The file cache is kept, so the next
+  `getLocaleData` re-merges it cheaply — no disk I/O.
+- `clearCache()` (`@visibleForTesting`) clears both caches and resets readiness;
+  `loadJSON()` must run again before reading data.
+
+**Lazy re-merge safety:** `getLocaleData` re-merges only when every *existing*
+file for the locale is cached; if one is missing it returns `null` rather than
+partial data. Absent files are skipped — e.g. `en-CW` has no `en-CW.json` and
+falls back to `en`.
+
 ---
 
 ## Performance Considerations

--- a/execute_test.sh
+++ b/execute_test.sh
@@ -55,7 +55,6 @@ Examples:
   ./execute_test.sh unit         # Run unit tests only
   ./execute_test.sh integration  # Run integration tests only
   ./execute_test.sh --help       # Show this help
-  ./execute_test.sh --help       # Show this help
 EOF
 }
 

--- a/lib/flutter_ilib.dart
+++ b/lib/flutter_ilib.dart
@@ -42,13 +42,10 @@ class FlutterILib extends ChangeNotifier {
   /// given.
   ///
   /// Setting it only updates the default string; it does not load data or
-  /// notify listeners. Unless the locale is already loaded, follow it with
-  /// [loadLocaleData], or consumers fall back to default data:
-  ///
-  /// ```dart
-  /// plugin.locale = 'fr-FR';
-  /// await plugin.loadLocaleData('fr-FR'); // loads data + notifies listeners
-  /// ```
+  /// notify listeners. Use it to point the default at an already-loaded
+  /// locale. To switch to a locale whose data is not loaded yet, call
+  /// [loadLocaleData] instead — it loads the data and updates this default in
+  /// one step; otherwise consumers fall back to default data.
   String get locale => ilib_utils.getLocale();
   set locale(String value) => ilib_utils.setLocale(value);
 
@@ -65,8 +62,16 @@ class FlutterILib extends ChangeNotifier {
   ///
   /// To properly load the updated locale data file,
   /// this should be called at the appropriate time when the locale changes.
+  ///
+  /// Passing an explicit [locale] also updates the app-wide default [locale],
+  /// so the two stay in sync and a locale-less formatter created afterwards
+  /// uses the locale just loaded. Passing null reloads the current locale and
+  /// leaves the default unchanged.
   Future<void> loadLocaleData(String? locale) async {
     logger.debug('[FlutterILib] Loading locale data for $locale');
+    if (locale != null) {
+      this.locale = locale;
+    }
     await ILibLoader.instance.loadILibLocaleData(locale);
   }
 

--- a/lib/flutter_ilib.dart
+++ b/lib/flutter_ilib.dart
@@ -41,11 +41,9 @@ class FlutterILib extends ChangeNotifier {
   /// The app-wide default locale, used when no per-call `options.locale` is
   /// given.
   ///
-  /// Setting it only updates the default string — it neither loads data nor
-  /// notifies listeners, and only instances created afterwards pick it up.
-  /// Unless the locale's data was already loaded (e.g. the system locale at
-  /// startup, or a prior [loadLocaleData]), you must call [loadLocaleData]
-  /// after setting it; otherwise consumers fall back to default data:
+  /// Setting it only updates the default string; it does not load data or
+  /// notify listeners. Unless the locale is already loaded, follow it with
+  /// [loadLocaleData], or consumers fall back to default data:
   ///
   /// ```dart
   /// plugin.locale = 'fr-FR';

--- a/lib/flutter_ilib.dart
+++ b/lib/flutter_ilib.dart
@@ -4,6 +4,7 @@ library flutter_ilib;
 import 'package:flutter/foundation.dart';
 
 import 'ilib_init.dart';
+import 'internal/ilib_utils.dart' as ilib_utils;
 import 'internal/logger/log_adapter.dart';
 import 'internal/logger/logger_selector.dart';
 
@@ -37,6 +38,22 @@ class FlutterILib extends ChangeNotifier {
   /// Return whether iLib is ready
   bool get isILibReady => ILibLoader.instance.isILibReady;
 
+  /// The app-wide default locale, used when no per-call `options.locale` is
+  /// given.
+  ///
+  /// Setting it only updates the default string — it neither loads data nor
+  /// notifies listeners, and only instances created afterwards pick it up.
+  /// Unless the locale's data was already loaded (e.g. the system locale at
+  /// startup, or a prior [loadLocaleData]), you must call [loadLocaleData]
+  /// after setting it; otherwise consumers fall back to default data:
+  ///
+  /// ```dart
+  /// plugin.locale = 'fr-FR';
+  /// await plugin.loadLocaleData('fr-FR'); // loads data + notifies listeners
+  /// ```
+  String get locale => ilib_utils.getLocale();
+  set locale(String value) => ilib_utils.setLocale(value);
+
   /// Return the current version of flutter_ilib.
   String get getVersion => '2.0.0';
 
@@ -53,5 +70,15 @@ class FlutterILib extends ChangeNotifier {
   Future<void> loadLocaleData(String? locale) async {
     logger.debug('[FlutterILib] Loading locale data for $locale');
     await ILibLoader.instance.loadILibLocaleData(locale);
+  }
+
+  /// Drop the cached data for [locale] to reclaim memory.
+  ///
+  /// Optional: loaded data is normally kept for reuse. iLib stays ready and
+  /// other locales are untouched; the data is re-loaded on the next
+  /// [loadLocaleData] for [locale].
+  void clearLocaleData(String locale) {
+    logger.debug('[FlutterILib] Clearing locale data for $locale');
+    ILibLoader.instance.clearLocale(locale);
   }
 }

--- a/lib/ilib_init.dart
+++ b/lib/ilib_init.dart
@@ -239,6 +239,10 @@ class ILibLoader extends ChangeNotifier {
   }
 
   /// Load and cache JSON data for every locale in [getSupportedLocales].
+  ///
+  /// Mainly for tests that exercise many locales at once. Apps should prefer
+  /// lazy loading (the current locale plus [loadILibLocaleData] on change) —
+  /// loading all ~144 locales up front holds every merged locale in memory.
   Future<void> loadILibLocaleDataAll() async {
     final List<String> localelist = getSupportedLocales();
 

--- a/lib/ilib_init.dart
+++ b/lib/ilib_init.dart
@@ -41,13 +41,22 @@ class ILibLoader extends ChangeNotifier {
 
   final Set<String> _availableAssets = <String>{};
 
+  /// The most recently loaded locale. Drives the [loadILibLocaleData] notify
+  /// decision; distinct from [currentLocale] (the app-wide default).
+  String? _lastLoadedLocale;
+
   static const String _rootPath =
       'packages/flutter_ilib/assets/locale/root.json';
 
   /// The merged locale data for [locale], or null if [locale] has not been
   /// loaded. Data is resolved lazily from the file cache on first access.
+  ///
+  /// [locale] is normalized so the cache key matches the one used by
+  /// [loadILibLocaleData] (store) and [clearLocale] (drop); otherwise an
+  /// un-normalized spelling such as `ko_KR` would miss the `ko-KR` entry.
   Map<String, dynamic>? getLocaleData(String locale) {
-    return _localeDataMap[locale] ?? _mergeFromCache(locale);
+    final String key = normalizeLocale(locale);
+    return _localeDataMap[key] ?? _mergeFromCache(key);
   }
 
   /// Locale-independent data from root.json (e.g. `ilib.data.astro`).
@@ -64,6 +73,11 @@ class ILibLoader extends ChangeNotifier {
       final Map<String, dynamic>? data = _fileDataCache[path];
       if (data != null) {
         merged = _deepMerge(merged, data);
+      } else if (_assetExists(path)) {
+        // Exists on disk but not cached: merging would silently drop its data,
+        // so bail and let the caller load it first. (Files that don't exist are
+        // fine to skip — e.g. en-CW has no file and falls back to 'en'.)
+        return null;
       }
     }
     if (merged.isNotEmpty) {
@@ -71,6 +85,18 @@ class ILibLoader extends ChangeNotifier {
       return merged;
     }
     return null;
+  }
+
+  /// Whether [path] is a bundled asset, per the manifest. Accepts both the
+  /// `packages/flutter_ilib/...` and manifest-relative forms; false when the
+  /// manifest is unavailable.
+  bool _assetExists(String path) {
+    if (_availableAssets.isEmpty) {
+      return false;
+    }
+    return _availableAssets.contains(path) ||
+        _availableAssets
+            .contains(path.replaceFirst('packages/flutter_ilib/', ''));
   }
 
   Future<void> _loadAssetManifest() async {
@@ -167,6 +193,7 @@ class ILibLoader extends ChangeNotifier {
       curlocale = 'en-US';
     }
     await _loadLocaleData(curlocale);
+    _lastLoadedLocale = curlocale;
 
     initILib();
     logger.info('Notifying listeners after JSON loading');
@@ -189,9 +216,9 @@ class ILibLoader extends ChangeNotifier {
     logger.info('iLib initialization completed');
   }
 
-  /// Load and cache the JSON data for [locale], then notify listeners if the
-  /// active locale changed. Pass null to reload the current locale. No-op if
-  /// iLib is not yet ready.
+  /// Load and cache the JSON data for [locale], notifying listeners only if it
+  /// differs from the last loaded locale (reloading the same one is a no-op for
+  /// listeners). Pass null to reload the current locale. No-op if not ready.
   Future<void> loadILibLocaleData(String? locale) async {
     if (!_iLibPrepared) {
       return;
@@ -205,7 +232,8 @@ class ILibLoader extends ChangeNotifier {
 
     await _loadLocaleData(locale);
 
-    if (currentLocale != locale) {
+    if (_lastLoadedLocale != locale) {
+      _lastLoadedLocale = locale;
       notifyListeners();
     }
   }
@@ -217,5 +245,23 @@ class ILibLoader extends ChangeNotifier {
     for (final String lo in localelist) {
       await loadILibLocaleData(lo);
     }
+  }
+
+  /// Drop [locale]'s merged data to reclaim memory. Safe at runtime: iLib stays
+  /// ready and the shared file cache is kept, so [getLocaleData] re-merges it
+  /// cheaply on next access.
+  void clearLocale(String locale) {
+    _localeDataMap.remove(normalizeLocale(locale));
+  }
+
+  /// Clear every cache and reset iLib to not-ready; [loadJSON] must run again
+  /// before reading data. For reclaiming all memory and isolating test state.
+  /// The asset manifest is kept, as it never changes.
+  @visibleForTesting
+  void clearCache() {
+    _localeDataMap.clear();
+    _fileDataCache.clear();
+    _lastLoadedLocale = null;
+    _iLibPrepared = false;
   }
 }

--- a/test/basic/flutter_ilib_locale_test.dart
+++ b/test/basic/flutter_ilib_locale_test.dart
@@ -95,4 +95,32 @@ void main() {
       expect(calls, 1);
     });
   });
+
+  group('loadLocaleData / default locale sync', () {
+    test('loading an explicit locale updates the app-wide default', () async {
+      plugin.locale = 'fr-FR';
+
+      await plugin.loadLocaleData('ko-KR');
+
+      // The default follows the explicit load target, so a locale-less
+      // consumer created afterwards uses ko-KR, not the stale fr-FR.
+      expect(plugin.locale, 'ko-KR');
+    });
+
+    test('loading null reloads the current locale without changing it',
+        () async {
+      plugin.locale = 'de-DE';
+
+      await plugin.loadLocaleData(null);
+
+      expect(plugin.locale, 'de-DE');
+    });
+
+    test('the explicit locale is normalized before becoming the default',
+        () async {
+      await plugin.loadLocaleData('ko_KR');
+
+      expect(plugin.locale, 'ko-KR');
+    });
+  });
 }

--- a/test/basic/flutter_ilib_locale_test.dart
+++ b/test/basic/flutter_ilib_locale_test.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_ilib/flutter_ilib.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  debugPrint('Testing [flutter_ilib_locale_test.dart] file.');
+  final FlutterILib plugin = FlutterILib.instance;
+  final ILibLoader loader = ILibLoader.instance;
+
+  late String savedLocale;
+
+  setUp(() async {
+    savedLocale = plugin.locale;
+    await loader.loadJSON();
+  });
+
+  tearDown(() {
+    // Restore the shared singleton default locale for other suites.
+    plugin.locale = savedLocale;
+  });
+
+  group('locale getter/setter', () {
+    test('setting locale is reflected by the getter', () {
+      plugin.locale = 'ko-KR';
+      expect(plugin.locale, 'ko-KR');
+    });
+
+    test('setter normalizes the value (C/POSIX/und -> en-US)', () {
+      plugin.locale = 'C';
+      expect(plugin.locale, 'en-US');
+
+      plugin.locale = 'ko_KR';
+      expect(plugin.locale, 'ko-KR');
+    });
+
+    test('setting locale alone does NOT notify listeners', () {
+      int calls = 0;
+      void listener() => calls++;
+      plugin.addListener(listener);
+      addTearDown(() => plugin.removeListener(listener));
+
+      plugin.locale = 'fr-FR';
+      plugin.locale = 'de-DE';
+
+      expect(calls, 0);
+    });
+  });
+
+  group('loadLocaleData notify', () {
+    test('loading a different locale notifies exactly once', () async {
+      // Seed the last-loaded locale so the target below is a real change.
+      await plugin.loadLocaleData('en-US');
+
+      int calls = 0;
+      void listener() => calls++;
+      plugin.addListener(listener);
+      addTearDown(() => plugin.removeListener(listener));
+
+      await plugin.loadLocaleData('ko-KR');
+
+      expect(calls, 1);
+    });
+
+    test('reloading the same locale does not notify', () async {
+      await plugin.loadLocaleData('fr-FR');
+
+      int calls = 0;
+      void listener() => calls++;
+      plugin.addListener(listener);
+      addTearDown(() => plugin.removeListener(listener));
+
+      await plugin.loadLocaleData('fr-FR');
+
+      expect(calls, 0);
+    });
+
+    test(
+        'setting locale then loading it still notifies '
+        '(no order-dependent miss)', () async {
+      await plugin.loadLocaleData('en-US');
+
+      // Change the app-wide default first; notify must still fire on load
+      // because the decision is based on the last *loaded* locale, not the
+      // default locale.
+      plugin.locale = 'ja-JP';
+
+      int calls = 0;
+      void listener() => calls++;
+      plugin.addListener(listener);
+      addTearDown(() => plugin.removeListener(listener));
+
+      await plugin.loadLocaleData('ja-JP');
+
+      expect(calls, 1);
+    });
+  });
+}

--- a/test/basic/ilib_loader_cache_test.dart
+++ b/test/basic/ilib_loader_cache_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_ilib/flutter_ilib.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  debugPrint('Testing [ilib_loader_cache_test.dart] file.');
+  final ILibLoader loader = ILibLoader.instance;
+  final FlutterILib plugin = FlutterILib.instance;
+
+  setUp(() async {
+    await loader.loadJSON();
+    await loader.loadILibLocaleData('en-US');
+  });
+
+  group('clearLocale', () {
+    test('drops the cached locale but keeps iLib ready', () async {
+      expect(loader.getLocaleData('en-US'), isNotNull);
+      expect(loader.isILibReady, true);
+
+      loader.clearLocale('en-US');
+
+      // iLib stays ready; data re-merges lazily from the file cache.
+      expect(loader.isILibReady, true);
+      expect(loader.getLocaleData('en-US'), isNotNull);
+    });
+
+    test('leaves other locales untouched', () async {
+      await loader.loadILibLocaleData('fr-FR');
+      expect(loader.getLocaleData('fr-FR'), isNotNull);
+
+      loader.clearLocale('en-US');
+
+      expect(loader.getLocaleData('fr-FR'), isNotNull);
+    });
+
+    test('normalizes the locale key (underscore spelling matches)', () async {
+      // Data is stored under the normalized key 'ko-KR'. clearLocale and
+      // getLocaleData must normalize too, so the underscore spelling resolves
+      // to the same entry instead of missing it.
+      await loader.loadILibLocaleData('ko-KR');
+      expect(loader.getLocaleData('ko_KR'), isNotNull);
+
+      loader.clearLocale('ko_KR');
+
+      // Re-merges from the file cache under the normalized key.
+      expect(loader.getLocaleData('ko-KR'), isNotNull);
+    });
+  });
+
+  group('getLocaleData lazy merge', () {
+    test('returns null when an existing asset is not cached yet', () {
+      // de-DE.json exists on disk but has not been loaded in this test, so it
+      // is not in the file cache. getLocaleData must not fabricate partial data
+      // from the ancestor files (root/de) that happen to be cached — merging
+      // now would silently drop de-DE.json, so it returns null instead.
+      expect(loader.getLocaleData('de-DE'), isNull);
+    });
+
+    test('re-merges a locale that was loaded then cleared', () async {
+      await loader.loadILibLocaleData('de-DE');
+      expect(loader.getLocaleData('de-DE'), isNotNull);
+
+      loader.clearLocale('de-DE');
+
+      // Every file is still in the shared file cache, so the merge is complete
+      // and the data comes back on next access.
+      expect(loader.getLocaleData('de-DE'), isNotNull);
+    });
+
+    test('resolves a region with no file of its own via language fallback', () {
+      // en-CW has no en-CW.json (nor und-CW.json); it legitimately resolves to
+      // the 'en' language data. Once root+en are cached (loadJSON loaded the
+      // en-US system locale), the merge is complete despite the absent files,
+      // so getLocaleData returns data rather than null.
+      expect(loader.getLocaleData('en-CW'), isNotNull);
+    });
+  });
+
+  group('clearCache', () {
+    test('resets to the not-ready state', () async {
+      expect(loader.isILibReady, true);
+
+      loader.clearCache();
+
+      expect(loader.isILibReady, false);
+
+      // Restore shared singleton state for the rest of the suite.
+      await loader.loadJSON();
+      expect(loader.isILibReady, true);
+    });
+  });
+
+  group('FlutterILib.clearLocaleData wrapper', () {
+    test('delegates to ILibLoader.clearLocale', () async {
+      expect(loader.getLocaleData('en-US'), isNotNull);
+
+      plugin.clearLocaleData('en-US');
+
+      // iLib stays ready and the data re-merges from the file cache.
+      expect(loader.isILibReady, true);
+      expect(loader.getLocaleData('en-US'), isNotNull);
+    });
+  });
+}


### PR DESCRIPTION
### Checklist

The following lists affects Pub Points on pub.dev when the package is published.
* [ ] Passed the all tests.
* [ ] Verified that the example app works.
* [ ] Executed the `dart format` command.
* [ ] Added the API description is added if necessary.

## Summary

Add a locale/cache management API to `FlutterILib` / `ILibLoader`, and harden the
lazy locale-data merge so cached data can be reclaimed and re-resolved safely.

## Changes

### Public API (`lib/flutter_ilib.dart`)
- `FlutterILib.locale` getter/setter — read or set the app-wide default locale.
  Setting it only updates the default string; call `loadLocaleData` to actually
  load data and notify listeners.
- `FlutterILib.clearLocaleData(locale)` — drop a cached locale to reclaim memory.
  iLib stays ready and other locales are untouched; the data re-merges from the
  file cache on next access.

### Loader (`lib/ilib_init.dart`)
- `ILibLoader.clearLocale(locale)` — backing implementation for the wrapper above.
- `ILibLoader.clearCache()` (`@visibleForTesting`) — reset all caches for test
  isolation.
- **Normalized cache keys**: `getLocaleData`, `loadILibLocaleData`, and
  `clearLocale` now all normalize the locale, so spellings like `ko_KR` resolve to
  the same `ko-KR` entry instead of missing it.
- **Safe lazy re-merge**: `getLocaleData` re-merges from the file cache only when
  every *existing* asset for the locale is cached. If a file that exists on disk is
  not cached yet, it returns `null` instead of silently partial data. Absent files
  are skipped normally (e.g. `en-CW` has no `en-CW.json` and falls back to `en`).

### Docs
- `docs/architecture.md`: document the two-level cache — normalized keys, the
  `clearLocale`/`clearCache` behavior, and the lazy re-merge safety rule.
- `README.md`: add an optional "Reclaiming locale memory" section.

### Misc
- `execute_test.sh`: remove a duplicated `--help` line.

## Tests
- `test/basic/ilib_loader_cache_test.dart` — `clearLocale`, `clearCache`, the
  `clearLocaleData` wrapper, locale-key normalization, and the lazy-merge cases
  (existing-but-uncached → null, loaded-then-cleared → re-merges, `en-CW` language
  fallback).
- `test/basic/flutter_ilib_locale_test.dart` — `locale` getter/setter, normalization,
  and `loadLocaleData` notify semantics.

All tests pass (`flutter test`) and `flutter analyze` is clean.
